### PR TITLE
Add configurable root path

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -89,20 +89,22 @@ func main() {
 	r.Use(hlog.MethodHandler("method"))
 	r.Use(hlog.RequestIDHandler("request_id", "Request-Id"))
 
-	r.Get("/metrics", server.HandleMetrics(conf.Prometheus.Token))
-	r.Get("/version", server.HandleVersion(source, version, commit))
-	r.Get("/healthz", server.HandleHealthz())
-	r.Get("/varz", server.HandleVarz(enginex))
-	r.Route("/api", func(r chi.Router) {
-		r.Use(server.CheckDrone(conf))
+	r.Route(conf.HTTP.Root, func(root chi.Router) {
+		root.Get("/metrics", server.HandleMetrics(conf.Prometheus.Token))
+		root.Get("/version", server.HandleVersion(source, version, commit))
+		root.Get("/healthz", server.HandleHealthz())
+		root.Get("/varz", server.HandleVarz(enginex))
+		root.Route("/api", func(api chi.Router) {
+			api.Use(server.CheckDrone(conf))
 
-		r.Post("/pause", server.HandleEnginePause(enginex))
-		r.Post("/resume", server.HandleEngineResume(enginex))
-		r.Get("/queue", server.HandleQueueList(client))
-		r.Get("/servers", server.HandleServerList(servers))
-		r.Post("/servers", server.HandleServerCreate(servers, conf))
-		r.Get("/servers/{name}", server.HandleServerFind(servers))
-		r.Delete("/servers/{name}", server.HandleServerDelete(servers))
+			api.Post("/pause", server.HandleEnginePause(enginex))
+			api.Post("/resume", server.HandleEngineResume(enginex))
+			api.Get("/queue", server.HandleQueueList(client))
+			api.Get("/servers", server.HandleServerList(servers))
+			api.Post("/servers", server.HandleServerCreate(servers, conf))
+			api.Get("/servers/{name}", server.HandleServerFind(servers))
+			api.Delete("/servers/{name}", server.HandleServerDelete(servers))
+		})
 	})
 
 	//

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type (
 		HTTP struct {
 			Host string
 			Port string `default:":8080"`
+			Root string `default:"/"`
 		}
 
 		TLS struct {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -34,6 +34,9 @@ func TestDefaults(t *testing.T) {
 	if got, want := conf.HTTP.Port, ":8080"; got != want {
 		t.Errorf("Want default DRONE_HTTP_PORT of %s, got %s", want, got)
 	}
+	if got, want := conf.HTTP.Root, "/"; got != want {
+		t.Errorf("Want default DRONE_HTTP_ROOT of %s, got %s", want, got)
+	}
 	if got, want := conf.Database.Driver, "sqlite3"; got != want {
 		t.Errorf("Want default DRONE_DATABASE_DRIVER of %s, got %s", want, got)
 	}
@@ -57,6 +60,7 @@ func TestLoad(t *testing.T) {
 		"DRONE_SERVER_TOKEN":            "633eb230f5",
 		"DRONE_HTTP_HOST":               "autoscaler.drone.company.com",
 		"DRONE_HTTP_PORT":               "633eb230f5",
+		"DRONE_HTTP_ROOT":               "/autoscaler",
 		"DRONE_AGENT_HOST":              "drone.company.com:9000",
 		"DRONE_AGENT_TOKEN":             "f5064039f5",
 		"DRONE_AGENT_IMAGE":             "drone/agent:0.8",
@@ -152,7 +156,8 @@ var jsonConfig = []byte(`{
   },
   "HTTP": {
     "Host": "autoscaler.drone.company.com",
-    "Port": "633eb230f5"
+    "Port": "633eb230f5",
+    "Root": "/autoscaler"
   },
   "TLS": {
     "Autocert": true,


### PR DESCRIPTION
I would like to avoid to add another sub domain "just" for the
autoscaler, with this config values it's possible to properly configure
the autoscaler to run on some specific root path, it defaults to / of
course.