### PR TITLE
Make cloud-init/userdata configurable

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -194,6 +194,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			digitalocean.WithSSHKey(c.DigitalOcean.SSHKey),
 			digitalocean.WithRegion(c.DigitalOcean.Region),
 			digitalocean.WithSize(c.DigitalOcean.Size),
+			digitalocean.WithUserData(c.DigitalOcean.UserData),
 			digitalocean.WithToken(c.DigitalOcean.Token),
 			digitalocean.WithTags(c.DigitalOcean.Tags...),
 		), nil
@@ -201,6 +202,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 		return hetznercloud.New(
 			hetznercloud.WithDatacenter(c.HetznerCloud.Datacenter),
 			hetznercloud.WithImage(c.HetznerCloud.Image),
+			hetznercloud.WithUserData(c.HetznerCloud.UserData),
 			hetznercloud.WithServerType(c.HetznerCloud.Type),
 			hetznercloud.WithSSHKey(c.HetznerCloud.SSHKey),
 			hetznercloud.WithToken(c.HetznerCloud.Token),
@@ -212,6 +214,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			amazon.WithSSHKey(c.Amazon.SSHKey),
 			amazon.WithSecurityGroup(c.Amazon.SecurityGroup...),
 			amazon.WithSize(c.Amazon.Instance),
+			amazon.WithUserData(c.Amazon.UserData),
 			amazon.WithSubnet(c.Amazon.SubnetID),
 			amazon.WithTags(c.Amazon.Tags),
 		), nil

--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,7 @@ type (
 
 		Amazon struct {
 			Instance      string
+			UserData      string `split_words:"true"`
 			Region        string
 			SSHKey        string
 			SubnetID      string   `split_words:"true"`
@@ -70,18 +71,20 @@ type (
 		}
 
 		DigitalOcean struct {
-			Token  string
-			Image  string
-			Region string
-			SSHKey string
-			Size   string
-			Tags   []string
+			Token    string
+			Image    string
+			UserData string `split_words:"true"`
+			Region   string
+			SSHKey   string
+			Size     string
+			Tags     []string
 		}
 
 		Google struct {
 			Zone         string `default:"us-central1-a"`
 			MachineType  string `split_words:"true" default:"n1-standard-1"`
 			MachineImage string `split_words:"true" default:"ubuntu-1510-wily-v20151114"`
+			UserData     string `split_words:"true"`
 			DiskType     string `split_words:"true" default:"pd-standard"`
 			Address      string
 			Network      string `default:"default"`
@@ -96,6 +99,7 @@ type (
 		HetznerCloud struct {
 			Datacenter string
 			Image      string
+			UserData   string `split_words:"true"`
 			SSHKey     int
 			Token      string
 			Type       string

--- a/drivers/amazon/create.go
+++ b/drivers/amazon/create.go
@@ -8,12 +8,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"text/template"
 	"time"
 
 	"github.com/drone/autoscaler"
 	"github.com/drone/autoscaler/drivers/internal/scripts"
 
-	"github.com/alecthomas/template"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/rs/zerolog/log"

--- a/drivers/amazon/create.go
+++ b/drivers/amazon/create.go
@@ -10,9 +10,10 @@ import (
 	"encoding/base64"
 	"time"
 
-	"github.com/alecthomas/template"
 	"github.com/drone/autoscaler"
+	"github.com/drone/autoscaler/drivers/internal/scripts"
 
+	"github.com/alecthomas/template"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/rs/zerolog/log"
@@ -24,7 +25,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 	})
 
 	buf := new(bytes.Buffer)
-	err := cloudInitT.Execute(buf, &opts)
+	err := p.userdata.Execute(buf, &opts)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +131,7 @@ poller:
 	return instance, nil
 }
 
-var cloudInitT = template.Must(template.New("_").Funcs(funcmap).Parse(`#cloud-config
+var cloudInitT = template.Must(template.New("_").Funcs(scripts.UserdataFuncmap).Parse(`#cloud-config
 
 apt_reboot_if_required: false
 package_update: false
@@ -179,9 +180,3 @@ runcmd:
   - [ systemctl, daemon-reload ]
   - [ systemctl, restart, docker ]
 `))
-
-var funcmap = map[string]interface{}{
-	"base64": func(src []byte) string {
-		return base64.StdEncoding.EncodeToString(src)
-	},
-}

--- a/drivers/amazon/option.go
+++ b/drivers/amazon/option.go
@@ -4,6 +4,10 @@
 
 package amazon
 
+import (
+	"github.com/drone/autoscaler/drivers/internal/scripts"
+)
+
 // Option configures a Digital Ocean provider option.
 type Option func(*provider)
 
@@ -11,6 +15,15 @@ type Option func(*provider)
 func WithImage(image string) Option {
 	return func(p *provider) {
 		p.image = image
+	}
+}
+
+// WithUserData returns an option to customize the cloud-init.
+func WithUserData(userdata string) Option {
+	return func(p *provider) {
+		if userdata != "" {
+			p.userdata = scripts.UserdataPrepare(userdata)
+		}
 	}
 }
 

--- a/drivers/amazon/provider.go
+++ b/drivers/amazon/provider.go
@@ -6,10 +6,10 @@ package amazon
 
 import (
 	"sync"
+	"text/template"
 
 	"github.com/drone/autoscaler"
 
-	"github.com/alecthomas/template"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/drivers/amazon/provider.go
+++ b/drivers/amazon/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/drone/autoscaler"
 
+	"github.com/alecthomas/template"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -24,14 +25,15 @@ const (
 type provider struct {
 	init sync.Once
 
-	retries int
-	key     string
-	region  string
-	image   string
-	size    string
-	subnet  string
-	groups  []string
-	tags    map[string]string
+	retries  int
+	key      string
+	region   string
+	image    string
+	userdata *template.Template
+	size     string
+	subnet   string
+	groups   []string
+	tags     map[string]string
 }
 
 func (p *provider) getClient() *ec2.EC2 {
@@ -57,6 +59,9 @@ func New(opts ...Option) autoscaler.Provider {
 	}
 	if p.image == "" {
 		p.image = "ami-66506c1c"
+	}
+	if p.userdata == nil {
+		p.userdata = cloudInitT
 	}
 	return p
 }

--- a/drivers/digitalocean/create.go
+++ b/drivers/digitalocean/create.go
@@ -8,12 +8,12 @@ import (
 	"bytes"
 	"context"
 	"strconv"
+	"text/template"
 	"time"
 
 	"github.com/drone/autoscaler"
 	"github.com/drone/autoscaler/drivers/internal/scripts"
 
-	"github.com/alecthomas/template"
 	"github.com/digitalocean/godo"
 	"github.com/rs/zerolog/log"
 )

--- a/drivers/digitalocean/create.go
+++ b/drivers/digitalocean/create.go
@@ -7,13 +7,13 @@ package digitalocean
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"strconv"
-	"text/template"
 	"time"
 
 	"github.com/drone/autoscaler"
+	"github.com/drone/autoscaler/drivers/internal/scripts"
 
+	"github.com/alecthomas/template"
 	"github.com/digitalocean/godo"
 	"github.com/rs/zerolog/log"
 )
@@ -24,7 +24,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 	})
 
 	buf := new(bytes.Buffer)
-	err := cloudInitT.Execute(buf, &opts)
+	err := p.userdata.Execute(buf, &opts)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ poller:
 	return instance, nil
 }
 
-var cloudInitT = template.Must(template.New("_").Funcs(funcmap).Parse(`#cloud-config
+var cloudInitT = template.Must(template.New("_").Funcs(scripts.UserdataFuncmap).Parse(`#cloud-config
 write_files:
   - path: /etc/systemd/system/docker.service.d/override.conf
     content: |
@@ -158,9 +158,3 @@ runcmd:
   - [ systemctl, daemon-reload ]
   - [ systemctl, restart, docker ]
 `))
-
-var funcmap = map[string]interface{}{
-	"base64": func(src []byte) string {
-		return base64.StdEncoding.EncodeToString(src)
-	},
-}

--- a/drivers/digitalocean/option.go
+++ b/drivers/digitalocean/option.go
@@ -4,7 +4,11 @@
 
 package digitalocean
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/drone/autoscaler/drivers/internal/scripts"
+)
 
 // Option configures a Digital Ocean provider option.
 type Option func(*provider)
@@ -13,6 +17,15 @@ type Option func(*provider)
 func WithImage(image string) Option {
 	return func(p *provider) {
 		p.image = image
+	}
+}
+
+// WithUserData returns an option to customize the cloud-init.
+func WithUserData(userdata string) Option {
+	return func(p *provider) {
+		if userdata != "" {
+			p.userdata = scripts.UserdataPrepare(userdata)
+		}
 	}
 }
 

--- a/drivers/digitalocean/provider.go
+++ b/drivers/digitalocean/provider.go
@@ -7,10 +7,10 @@ package digitalocean
 import (
 	"context"
 	"sync"
+	"text/template"
 
 	"github.com/drone/autoscaler"
 
-	"github.com/alecthomas/template"
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
 )

--- a/drivers/digitalocean/provider.go
+++ b/drivers/digitalocean/provider.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"sync"
 
-	"github.com/digitalocean/godo"
 	"github.com/drone/autoscaler"
+
+	"github.com/alecthomas/template"
+	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
 )
 
@@ -17,12 +19,13 @@ import (
 type provider struct {
 	init sync.Once
 
-	key    string
-	region string
-	token  string
-	size   string
-	image  string
-	tags   []string
+	key      string
+	region   string
+	token    string
+	size     string
+	image    string
+	userdata *template.Template
+	tags     []string
 }
 
 // New returns a new Digital Ocean provider.
@@ -39,6 +42,9 @@ func New(opts ...Option) autoscaler.Provider {
 	}
 	if p.image == "" {
 		p.image = "docker-16-04"
+	}
+	if p.userdata == nil {
+		p.userdata = cloudInitT
 	}
 	return p
 }

--- a/drivers/hetznercloud/create.go
+++ b/drivers/hetznercloud/create.go
@@ -7,12 +7,12 @@ package hetznercloud
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"strconv"
 
-	"github.com/alecthomas/template"
 	"github.com/drone/autoscaler"
+	"github.com/drone/autoscaler/drivers/internal/scripts"
 
+	"github.com/alecthomas/template"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/rs/zerolog/log"
 )
@@ -23,7 +23,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 	})
 
 	buf := new(bytes.Buffer)
-	err := cloudInitT.Execute(buf, &opts)
+	err := p.userdata.Execute(buf, &opts)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 	}, nil
 }
 
-var cloudInitT = template.Must(template.New("_").Funcs(funcmap).Parse(`#cloud-config
+var cloudInitT = template.Must(template.New("_").Funcs(scripts.UserdataFuncmap).Parse(`#cloud-config
 
 apt_reboot_if_required: false
 package_update: false
@@ -129,9 +129,3 @@ runcmd:
   - [ systemctl, daemon-reload ]
   - [ systemctl, restart, docker ]
 `))
-
-var funcmap = map[string]interface{}{
-	"base64": func(src []byte) string {
-		return base64.StdEncoding.EncodeToString(src)
-	},
-}

--- a/drivers/hetznercloud/create.go
+++ b/drivers/hetznercloud/create.go
@@ -8,11 +8,11 @@ import (
 	"bytes"
 	"context"
 	"strconv"
+	"text/template"
 
 	"github.com/drone/autoscaler"
 	"github.com/drone/autoscaler/drivers/internal/scripts"
 
-	"github.com/alecthomas/template"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/rs/zerolog/log"
 )

--- a/drivers/hetznercloud/option.go
+++ b/drivers/hetznercloud/option.go
@@ -4,7 +4,11 @@
 
 package hetznercloud
 
-import "github.com/hetznercloud/hcloud-go/hcloud"
+import (
+	"github.com/drone/autoscaler/drivers/internal/scripts"
+
+	"github.com/hetznercloud/hcloud-go/hcloud"
+)
 
 // Option configures a Digital Ocean provider option.
 type Option func(*provider)
@@ -27,6 +31,15 @@ func WithDatacenter(datacenter string) Option {
 func WithImage(image string) Option {
 	return func(p *provider) {
 		p.image = image
+	}
+}
+
+// WithUserData returns an option to customize the cloud-init.
+func WithUserData(userdata string) Option {
+	return func(p *provider) {
+		if userdata != "" {
+			p.userdata = scripts.UserdataPrepare(userdata)
+		}
 	}
 }
 

--- a/drivers/hetznercloud/provider.go
+++ b/drivers/hetznercloud/provider.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 
 	"github.com/drone/autoscaler"
+
+	"github.com/alecthomas/template"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 )
 
@@ -19,6 +21,7 @@ type provider struct {
 	datacenter string
 	serverType string
 	image      string
+	userdata   *template.Template
 	key        int
 
 	client *hcloud.Client
@@ -38,6 +41,9 @@ func New(opts ...Option) autoscaler.Provider {
 	}
 	if p.image == "" {
 		p.image = "ubuntu-16.04"
+	}
+	if p.userdata == nil {
+		p.userdata = cloudInitT
 	}
 	return p
 }

--- a/drivers/hetznercloud/provider.go
+++ b/drivers/hetznercloud/provider.go
@@ -6,10 +6,10 @@ package hetznercloud
 
 import (
 	"sync"
+	"text/template"
 
 	"github.com/drone/autoscaler"
 
-	"github.com/alecthomas/template"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 )
 

--- a/drivers/internal/scripts/userdata.go
+++ b/drivers/internal/scripts/userdata.go
@@ -1,0 +1,43 @@
+// Copyright 2018 Drone.IO Inc
+// Use of this software is governed by the Business Source License
+// that can be found in the LICENSE file.
+
+package scripts
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+
+	"github.com/alecthomas/template"
+)
+
+var (
+	UserdataFuncmap = map[string]interface{}{
+		"base64": func(src []byte) string {
+			return base64.StdEncoding.EncodeToString(src)
+		},
+	}
+)
+
+func UserdataPrepare(val string) *template.Template {
+	tmpl := template.New("_").Funcs(UserdataFuncmap)
+
+	if _, err := os.Stat(val); err == nil {
+		content, err := ioutil.ReadFile(val)
+
+		if err != nil {
+			return nil
+		}
+
+		return template.Must(tmpl.Parse(string(content)))
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(val)
+
+	if err != nil {
+		return template.Must(tmpl.Parse(val))
+	}
+
+	return template.Must(tmpl.Parse(string(decoded)))
+}

--- a/drivers/internal/scripts/userdata.go
+++ b/drivers/internal/scripts/userdata.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/alecthomas/template"
+	"text/template"
 )
 
 var (

--- a/drivers/internal/scripts/userdata_test.go
+++ b/drivers/internal/scripts/userdata_test.go
@@ -1,0 +1,86 @@
+// Copyright 2018 Drone.IO Inc
+// Use of this software is governed by the Business Source License
+// that can be found in the LICENSE file.
+
+package scripts
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestUserdataPrepare_File(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "test")
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(dummyUserdata)); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := tmpfile.Close(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	tmpl := UserdataPrepare(tmpfile.Name())
+	buf := new(bytes.Buffer)
+
+	if err := tmpl.Execute(buf, nil); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if got, want := buf.String(), dummyUserdata; got != want {
+		t.Errorf("Want parsed template of %v, got %v", want, got)
+	}
+}
+
+func TestUserdataPrepare_Base64(t *testing.T) {
+	input := base64.StdEncoding.EncodeToString([]byte(dummyUserdata))
+
+	tmpl := UserdataPrepare(input)
+	buf := new(bytes.Buffer)
+
+	if err := tmpl.Execute(buf, nil); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if got, want := buf.String(), dummyUserdata; got != want {
+		t.Errorf("Want parsed template of %v, got %v", want, got)
+	}
+
+}
+
+func TestUserdataPrepare_String(t *testing.T) {
+	input := dummyUserdata
+
+	tmpl := UserdataPrepare(input)
+	buf := new(bytes.Buffer)
+
+	if err := tmpl.Execute(buf, nil); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if got, want := buf.String(), dummyUserdata; got != want {
+		t.Errorf("Want parsed template of %v, got %v", want, got)
+	}
+
+}
+
+var dummyUserdata = `#cloud-config
+apt_reboot_if_required: false
+package_update: false
+package_upgrade: false
+`


### PR DESCRIPTION
Currently the userdata is staticaly compiled in, with this change the
admin is able to customize the userdata or cloud-init content, the
content can be provided via path, base64 encoded string or a plain
string.