### PR TITLE
Start a drone agent for each parallel process in the build

### DIFF
--- a/engine/planner.go
+++ b/engine/planner.go
@@ -212,10 +212,17 @@ func (p *planner) count(ctx context.Context) (pending, running int, err error) {
 		return pending, running, err
 	}
 	for _, activity := range activity {
-		if activity.Status == drone.StatusPending {
-			pending++
-		} else {
-			running++
+		build, err := p.client.Build(activity.Owner, activity.Name, activity.Number);
+		if err != nil {
+			return pending, running, err
+		}
+
+		for _, process := range build.Procs {
+			if process.Status == drone.StatusPending {
+				pending++
+			} else {
+				running++
+			}
 		}
 	}
 	return

--- a/engine/planner.go
+++ b/engine/planner.go
@@ -218,7 +218,7 @@ func (p *planner) count(ctx context.Context) (pending, running int, err error) {
 		}
 
 		for _, process := range build.Procs {
-			if process.Status == drone.StatusPending {
+			if process.State == drone.StatusPending {
 				pending++
 			} else {
 				running++

--- a/engine/planner_test.go
+++ b/engine/planner_test.go
@@ -82,27 +82,13 @@ func TestPlan_MaxCapacity(t *testing.T) {
 		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
 		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
 	}
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
 
 	store := mocks.NewMockServerStore(controller)
 	store.EXPECT().List(gomock.Any()).Return(servers, nil)
@@ -157,39 +143,17 @@ func TestPlan_MoreCapacity(t *testing.T) {
 		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42}, // ignore, would exceed max pool size
 		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42}, // ignore, would exceed max pool size
 	}
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusPending}]
-	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
 
 	store := mocks.NewMockServerStore(controller)
 	store.EXPECT().List(gomock.Any()).Return(servers, nil)
@@ -275,19 +239,11 @@ func TestPlan_NoIdle(t *testing.T) {
 
 	client := mocks.NewMockClient(controller)
 	client.EXPECT().BuildQueue().Return(builds, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
 	client.EXPECT().BuildQueue().Return(builds, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
-	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
-		Procs: [{State: drone.StatusRunning}]
-	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
 	client.EXPECT().Build(gomock.Any(), gomock.Any(), gomock.Any()).Return(&drone.Build{Procs: []*drone.Proc{{Machine: "server1"}}}, nil)
 	client.EXPECT().Build(gomock.Any(), gomock.Any(), gomock.Any()).Return(&drone.Build{Procs: []*drone.Proc{{Machine: "server2"}}}, nil)
 

--- a/engine/planner_test.go
+++ b/engine/planner_test.go
@@ -34,10 +34,13 @@ func TestPlan_Noop(t *testing.T) {
 
 	client := mocks.NewMockClient(controller)
 	client.EXPECT().BuildQueue().Return([]*drone.Activity{
-		{Status: drone.StatusRunning},
-		{Status: drone.StatusPending},
-		{Status: drone.StatusPending},
+		{Status: drone.StatusRunning, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
 	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusRunning}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(&drone.Build{Procs: []*drone.Proc{{State: drone.StatusPending}}}, nil)
 
 	p := planner{
 		cap:     2,
@@ -71,14 +74,35 @@ func TestPlan_MaxCapacity(t *testing.T) {
 	// x4 running builds
 	// x3 pending builds
 	builds := []*drone.Activity{
-		{Status: drone.StatusRunning},
-		{Status: drone.StatusRunning},
-		{Status: drone.StatusRunning},
-		{Status: drone.StatusRunning},
-		{Status: drone.StatusPending},
-		{Status: drone.StatusPending},
-		{Status: drone.StatusPending},
+		{Status: drone.StatusRunning, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusRunning, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusRunning, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusRunning, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
 	}
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
 
 	store := mocks.NewMockServerStore(controller)
 	store.EXPECT().List(gomock.Any()).Return(servers, nil)
@@ -121,18 +145,51 @@ func TestPlan_MoreCapacity(t *testing.T) {
 	// x2 running builds
 	// x3 pending builds
 	builds := []*drone.Activity{
-		{Status: drone.StatusRunning},
-		{Status: drone.StatusRunning},
-		{Status: drone.StatusPending},
-		{Status: drone.StatusPending},
-		{Status: drone.StatusPending},
-		{Status: drone.StatusPending}, // ignore, would exceed max pool size
-		{Status: drone.StatusPending}, // ignore, would exceed max pool size
-		{Status: drone.StatusPending}, // ignore, would exceed max pool size
-		{Status: drone.StatusPending}, // ignore, would exceed max pool size
-		{Status: drone.StatusPending}, // ignore, would exceed max pool size
-		{Status: drone.StatusPending}, // ignore, would exceed max pool size
+		{Status: drone.StatusRunning, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusRunning, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42}, // ignore, would exceed max pool size
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42}, // ignore, would exceed max pool size
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42}, // ignore, would exceed max pool size
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42}, // ignore, would exceed max pool size
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42}, // ignore, would exceed max pool size
+		{Status: drone.StatusPending, Owner: "foo", Name: "bar", Number: 42}, // ignore, would exceed max pool size
 	}
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusPending}]
+	}, nil)
 
 	store := mocks.NewMockServerStore(controller)
 	store.EXPECT().List(gomock.Any()).Return(servers, nil)
@@ -208,8 +265,8 @@ func TestPlan_NoIdle(t *testing.T) {
 	// x2 running builds
 	// x0 pending builds
 	builds := []*drone.Activity{
-		{Status: drone.StatusRunning},
-		{Status: drone.StatusRunning},
+		{Status: drone.StatusRunning, Owner: "foo", Name: "bar", Number: 42},
+		{Status: drone.StatusRunning, Owner: "foo", Name: "bar", Number: 42},
 	}
 
 	store := mocks.NewMockServerStore(controller)
@@ -218,7 +275,19 @@ func TestPlan_NoIdle(t *testing.T) {
 
 	client := mocks.NewMockClient(controller)
 	client.EXPECT().BuildQueue().Return(builds, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
 	client.EXPECT().BuildQueue().Return(builds, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
+	client.EXPECT().Build("foo", "bar", 42).Return(drone.Build{
+		Procs: [{State: drone.StatusRunning}]
+	}, nil)
 	client.EXPECT().Build(gomock.Any(), gomock.Any(), gomock.Any()).Return(&drone.Build{Procs: []*drone.Proc{{Machine: "server1"}}}, nil)
 	client.EXPECT().Build(gomock.Any(), gomock.Any(), gomock.Any()).Return(&drone.Build{Procs: []*drone.Proc{{Machine: "server2"}}}, nil)
 


### PR DESCRIPTION
Use the number of processes for a build to calculate the required number of Drone agents.
