### PR TITLE
add keepalive functionality to booting agents

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,10 +35,12 @@ type (
 		}
 
 		Agent struct {
-			Host        string
-			Token       string
-			Image       string `default:"drone/agent:0.8"`
-			Concurrency int    `default:"2"`
+			Host             string
+			Token            string
+			Image            string        `default:"drone/agent:0.8"`
+			Concurrency      int           `default:"2"`
+			KeepaliveTime    time.Duration `default:"6m"`
+			KeepaliveTimeout time.Duration `default:"30s"`
 		}
 
 		HTTP struct {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -169,7 +169,9 @@ var jsonConfig = []byte(`{
     "Host": "drone.company.com:9000",
     "Token": "f5064039f5",
     "Image": "drone/agent:0.8",
-    "Concurrency": 2
+    "Concurrency": 2,
+    "KeepaliveTime": 360000000000,
+    "KeepaliveTimeout": 30000000000
   },
   "HTTP": {
     "Host": "autoscaler.drone.company.com",

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -56,6 +56,8 @@ func New(
 			image:   config.Agent.Image,
 			secret:  config.Agent.Token,
 			server:  config.Agent.Host,
+			keepaliveTime: config.Agent.KeepaliveTime,
+			keepaliveTimeout: config.Agent.KeepaliveTimeout,
 			client:  newDockerClient,
 		},
 		planner: &planner{

--- a/engine/install.go
+++ b/engine/install.go
@@ -25,6 +25,8 @@ type installer struct {
 	image  string
 	secret string
 	server string
+	keepaliveTime time.Duration
+	keepaliveTimeout time.Duration
 
 	servers autoscaler.ServerStore
 	client  clientFunc
@@ -133,6 +135,8 @@ poller:
 				fmt.Sprintf("DRONE_SERVER=%s", i.server),
 				fmt.Sprintf("DRONE_MAX_PROCS=%v", instance.Capacity),
 				fmt.Sprintf("DRONE_HOSTNAME=%s", instance.Name),
+				fmt.Sprintf("DRONE_KEEPALIVE_TIME=%s", i.keepaliveTime),
+				fmt.Sprintf("DRONE_KEEPALIVE_TIMEOUT=%s", i.keepaliveTimeout),
 			},
 			Volumes: map[string]struct{}{
 				"/var/run/docker.sock": {},


### PR DESCRIPTION
This helps with tcp loadbalancers which would otherwise timeout the
connection. Having the connection timeout is problematic because the
drone-agent does not recognize that it lost the connection.

This keepalive features was added in drone-agent 0.8.4 hence we bump
the default version to 0.8.4

<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->