### PR TITLE
ignore stopped/shutdown/stopping/error from current capacity

### DIFF
--- a/engine/planner.go
+++ b/engine/planner.go
@@ -258,6 +258,12 @@ func (p *planner) capacity(ctx context.Context) (capacity, count int, err error)
 		switch server.State {
 		case autoscaler.StateStopped:
 			// ignore state
+		case autoscaler.StateShutdown:
+			// ignore state
+		case autoscaler.StateStopping:
+			// ignore state
+		case autoscaler.StateError:
+			// ignore state
 		default:
 			count++
 			capacity += server.Capacity


### PR DESCRIPTION
the following states shutdown/stoppping/error should not count as available capacity.
so we ignore these as well next to stopped

<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->