### PR TITLE
Fix some copy/pasta typo on providers

### DIFF
--- a/drivers/amazon/create.go
+++ b/drivers/amazon/create.go
@@ -96,7 +96,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		Str("name", instance.Name).
 		Msg("instance create success")
 
-	// poll the digitalocean endpoint for server updates
+	// poll the amazon endpoint for server updates
 	// and exit when a network address is allocated.
 	interval := time.Duration(0)
 poller:

--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -15,8 +15,7 @@ import (
 	"github.com/drone/autoscaler/drivers/internal/userdata"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-
-	"google.golang.org/api/compute/v1"
+	compute "google.golang.org/api/compute/v1"
 )
 
 var (
@@ -32,7 +31,7 @@ var (
 	}
 )
 
-// provider implements a DigitalOcean provider.
+// provider implements a Google provider.
 type provider struct {
 	init sync.Once
 


### PR DESCRIPTION
… mainly Digitalocean used in other provider comments.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
