### PR TITLE
 Make notifications configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,9 @@ type (
 
 		Slack struct {
 			Webhook string
+			Create  bool `default:"true"`
+			Destroy bool `default:"true"`
+			Error   bool `default:"true"`
 		}
 
 		Logs struct {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -55,8 +55,8 @@ func TestLoad(t *testing.T) {
 	environ := map[string]string{
 		"DRONE_INTERVAL":                   "1m",
 		"DRONE_SLACK_WEBHOOK":              "https://hooks.slack.com/services/XXX/YYY/ZZZ",
-    "DRONE_SLACK_CREATE":               "false",
-    "DRONE_SLACK_DESTROY":              "false",
+		"DRONE_SLACK_CREATE":               "false",
+		"DRONE_SLACK_DESTROY":              "false",
 		"DRONE_LOGS_DEBUG":                 "true",
 		"DRONE_LOGS_COLOR":                 "true",
 		"DRONE_LOGS_PRETTY":                "true",

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -55,6 +55,8 @@ func TestLoad(t *testing.T) {
 	environ := map[string]string{
 		"DRONE_INTERVAL":                   "1m",
 		"DRONE_SLACK_WEBHOOK":              "https://hooks.slack.com/services/XXX/YYY/ZZZ",
+    "DRONE_SLACK_CREATE":               "false",
+    "DRONE_SLACK_DESTROY":              "false",
 		"DRONE_LOGS_DEBUG":                 "true",
 		"DRONE_LOGS_COLOR":                 "true",
 		"DRONE_LOGS_PRETTY":                "true",
@@ -148,7 +150,10 @@ func TestLoad(t *testing.T) {
 var jsonConfig = []byte(`{
   "Interval": 60000000000,
   "Slack": {
-    "Webhook": "https://hooks.slack.com/services/XXX/YYY/ZZZ"
+    "Webhook": "https://hooks.slack.com/services/XXX/YYY/ZZZ",
+    "Create": false,
+    "Destroy": false,
+    "Error": true
   },
   "Logs": {
     "Color": true,

--- a/engine/planner.go
+++ b/engine/planner.go
@@ -6,9 +6,9 @@ package engine
 
 import (
 	"context"
+	"os"
 	"sort"
 	"time"
-	"os"
 
 	"github.com/drone/autoscaler"
 	"github.com/drone/autoscaler/limiter"
@@ -231,17 +231,17 @@ func (p *planner) countMatrix(ctx context.Context) (pending, running int, err er
 		return pending, running, err
 	}
 	for _, activity := range activity {
-		build, err := p.client.Build(activity.Owner, activity.Name, activity.Number);
+		build, err := p.client.Build(activity.Owner, activity.Name, activity.Number)
 		if err != nil {
 			return pending, running, err
 		}
 
 		for _, process := range build.Procs {
 			switch process.State {
-				case drone.StatusPending:
-					pending++
-				case drone.StatusRunning:
-					running++
+			case drone.StatusPending:
+				pending++
+			case drone.StatusRunning:
+				running++
 			}
 		}
 	}

--- a/engine/planner_test.go
+++ b/engine/planner_test.go
@@ -6,9 +6,9 @@ package engine
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
-	"os"
 
 	"github.com/drone/autoscaler"
 	"github.com/drone/autoscaler/config"
@@ -320,9 +320,9 @@ func TestPlan_ShutdownIdle(t *testing.T) {
 // and the server capacity is < the pool maximum,
 // additional servers are provisioned.
 func TestPlan_MatrixMoreCapacity(t *testing.T) {
-	os.Setenv("ENABLE_MATRIX_CALC", "true");
-	defer os.Unsetenv("ENABLE_MATRIX_CALC");
-	
+	os.Setenv("ENABLE_MATRIX_CALC", "true")
+	defer os.Unsetenv("ENABLE_MATRIX_CALC")
+
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
@@ -345,7 +345,7 @@ func TestPlan_MatrixMoreCapacity(t *testing.T) {
 
 	client := mocks.NewMockClient(controller)
 	client.EXPECT().BuildQueue().Return(builds, nil)
-	
+
 	// pending build has 4 processes
 	client.EXPECT().Build(gomock.Any(), gomock.Any(), gomock.Any()).Return(&drone.Build{Procs: []*drone.Proc{
 		{State: drone.StatusPending},

--- a/slack/slack_test.go
+++ b/slack/slack_test.go
@@ -49,6 +49,7 @@ func TestUpdateRunning(t *testing.T) {
 
 	conf := config.Config{}
 	conf.Slack.Webhook = "https://hooks.slack.com/services/XXX/YYY/ZZZ"
+	conf.Slack.Create = true
 
 	store := mocks.NewMockServerStore(controller)
 	store.EXPECT().Update(gomock.Any(), server).Return(nil)
@@ -83,6 +84,7 @@ func TestUpdateStopped(t *testing.T) {
 
 	conf := config.Config{}
 	conf.Slack.Webhook = "https://hooks.slack.com/services/XXX/YYY/ZZZ"
+	conf.Slack.Destroy = true
 
 	store := mocks.NewMockServerStore(controller)
 	store.EXPECT().Update(gomock.Any(), server).Return(nil)
@@ -120,6 +122,7 @@ func TestUpdateError(t *testing.T) {
 
 	conf := config.Config{}
 	conf.Slack.Webhook = "https://hooks.slack.com/services/XXX/YYY/ZZZ"
+	conf.Slack.Error = true
 
 	store := mocks.NewMockServerStore(controller)
 	store.EXPECT().Update(gomock.Any(), server).Return(nil)


### PR DESCRIPTION
Now you can enable or disable slack notifications for specific types:

* create
* destroy
* error