### PR TITLE
allow host volume mounts for drone agents

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,8 @@ type (
 			Volumes	    []string
 		}
 
+		Runner Runner
+
 		HTTP struct {
 			Host string
 			Port string `default:":8080"`
@@ -150,5 +152,11 @@ type (
 			UserData      string `envconfig:"DRONE_OPENSTACK_USERDATA"`
 			UserDataFile  string `envconfig:"DRONE_OPENSTACK_USERDATA_FILE"`
 		}
+	}
+
+	Runner struct {
+		Volumes	    string
+		Devices     string
+		Privileged  string
 	}
 )

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type (
 			Arch        string `default:"amd64"`
 			Version     string
 			Kernel      string
+			Volumes	    []string
 		}
 
 		HTTP struct {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -61,6 +61,7 @@ func New(
 			proto:   config.Server.Proto,
 			host:    config.Server.Host,
 			client:  newDockerClient,
+			runner:  config.Runner,
 		},
 		pinger: &pinger{
 			servers: servers,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -57,6 +57,7 @@ func New(
 			servers: servers,
 			image:   config.Agent.Image,
 			secret:  config.Agent.Token,
+			volumes: config.Agent.Volumes,
 			proto:   config.Server.Proto,
 			host:    config.Server.Host,
 			client:  newDockerClient,

--- a/engine/install.go
+++ b/engine/install.go
@@ -7,6 +7,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"github.com/drone/autoscaler/config"
 	"io"
 	"io/ioutil"
 	"sync"
@@ -31,6 +32,7 @@ type installer struct {
 	proto            string
 	keepaliveTime    time.Duration
 	keepaliveTimeout time.Duration
+	runner 	         config.Runner
 
 	servers autoscaler.ServerStore
 	client  clientFunc
@@ -140,6 +142,9 @@ poller:
 				fmt.Sprintf("DRONE_RPC_SECRET=%s", i.secret),
 				fmt.Sprintf("DRONE_RUNNER_CAPACITY=%v", instance.Capacity),
 				fmt.Sprintf("DRONE_RUNNER_NAME=%s", instance.Name),
+				fmt.Sprintf("DRONE_RUNNER_VOLUMES=%s", i.runner.Volumes),
+				fmt.Sprintf("DRONE_RUNNER_DEVICES=%s", i.runner.Devices),
+				fmt.Sprintf("DRONE_RUNNER_PRIVILEGED_IMAGES=%s", i.runner.Privileged),
 			},
 			Volumes: toVol(i.volumes),
 			Labels: map[string]string{

--- a/engine/install.go
+++ b/engine/install.go
@@ -131,7 +131,7 @@ poller:
 		Str("image", i.image).
 		Msg("create agent container")
 
-	i.volumes = append(i.volumes, "/var/run/docker.sock:/var/run/docker.sock")
+	var volumes = append(i.volumes, "/var/run/docker.sock:/var/run/docker.sock")
 	res, err := client.ContainerCreate(ctx,
 		&container.Config{
 			Image:        i.image,
@@ -146,7 +146,7 @@ poller:
 				fmt.Sprintf("DRONE_RUNNER_DEVICES=%s", i.runner.Devices),
 				fmt.Sprintf("DRONE_RUNNER_PRIVILEGED_IMAGES=%s", i.runner.Privileged),
 			},
-			Volumes: toVol(i.volumes),
+			Volumes: toVol(volumes),
 			Labels: map[string]string{
 				"com.centurylinklabs.watchtower.enable":      "true",
 				"com.centurylinklabs.watchtower.stop-signal": "SIGHUP",
@@ -158,7 +158,7 @@ poller:
 			},
 		},
 		&container.HostConfig{
-			Binds: i.volumes,
+			Binds: volumes,
 			RestartPolicy: container.RestartPolicy{
 				Name: "always",
 			},

--- a/engine/install_test.go
+++ b/engine/install_test.go
@@ -3,3 +3,76 @@
 // that can be found in the LICENSE file.
 
 package engine
+
+import (
+"reflect"
+"testing"
+)
+
+func TestSplitVolumeParts(t *testing.T) {
+	testdata := []struct {
+		from    string
+		to      []string
+		success bool
+	}{
+		{
+			from:    `Z::Z::rw`,
+			to:      []string{`Z:`, `Z:`, `rw`},
+			success: true,
+		},
+		{
+			from:    `Z:\:Z:\:rw`,
+			to:      []string{`Z:\`, `Z:\`, `rw`},
+			success: true,
+		},
+		{
+			from:    `Z:\git\refs:Z:\git\refs:rw`,
+			to:      []string{`Z:\git\refs`, `Z:\git\refs`, `rw`},
+			success: true,
+		},
+		{
+			from:    `Z:\git\refs:Z:\git\refs`,
+			to:      []string{`Z:\git\refs`, `Z:\git\refs`},
+			success: true,
+		},
+		{
+			from:    `Z:/:Z:/:rw`,
+			to:      []string{`Z:/`, `Z:/`, `rw`},
+			success: true,
+		},
+		{
+			from:    `Z:/git/refs:Z:/git/refs:rw`,
+			to:      []string{`Z:/git/refs`, `Z:/git/refs`, `rw`},
+			success: true,
+		},
+		{
+			from:    `Z:/git/refs:Z:/git/refs`,
+			to:      []string{`Z:/git/refs`, `Z:/git/refs`},
+			success: true,
+		},
+		{
+			from:    `/test:/test`,
+			to:      []string{`/test`, `/test`},
+			success: true,
+		},
+		{
+			from:    `test:/test`,
+			to:      []string{`test`, `/test`},
+			success: true,
+		},
+		{
+			from:    `test:test`,
+			to:      []string{`test`, `test`},
+			success: true,
+		},
+	}
+	for _, test := range testdata {
+		results, err := splitVolumeParts(test.from)
+		if test.success == (err != nil) {
+		} else {
+			if reflect.DeepEqual(results, test.to) != test.success {
+				t.Errorf("Expect %q matches %q is %v", test.from, results, test.to)
+			}
+		}
+	}
+}

--- a/engine/install_test.go
+++ b/engine/install_test.go
@@ -5,8 +5,8 @@
 package engine
 
 import (
-"reflect"
-"testing"
+	"reflect"
+	"testing"
 )
 
 func TestSplitVolumeParts(t *testing.T) {


### PR DESCRIPTION
Today we encountered the issue with drone 1.0 agents, that they can not work with self-signed certificates on the drone server as we are not able to mount our ca.

This PR attempts to provide a environment variable in which one can define arbitrary host to agent-container mounts 