### PR TITLE
Updated the default DigitalOcean image to use to 'docker-18-04'.

### DIFF
--- a/config/load_test.go
+++ b/config/load_test.go
@@ -79,7 +79,7 @@ func TestLoad(t *testing.T) {
 		"DRONE_DATABASE_DRIVER":            "mysql",
 		"DRONE_DATABASE_DATASOURCE":        "user:password@/dbname",
 		"DRONE_DIGITALOCEAN_TOKEN":         "2573633eb",
-		"DRONE_DIGITALOCEAN_IMAGE":         "docker-16-04",
+		"DRONE_DIGITALOCEAN_IMAGE":         "docker-18-04",
 		"DRONE_DIGITALOCEAN_REGION":        "ncy1",
 		"DRONE_DIGITALOCEAN_SSHKEY":        "/path/to/ssh/key",
 		"DRONE_DIGITALOCEAN_SIZE":          "s-1vcpu-1gb",
@@ -216,7 +216,7 @@ var jsonConfig = []byte(`{
   },
   "DigitalOcean": {
     "Token": "2573633eb",
-    "Image": "docker-16-04",
+    "Image": "docker-18-04",
     "Region": "ncy1",
     "SSHKey": "/path/to/ssh/key",
     "Size": "s-1vcpu-1gb",

--- a/drivers/digitalocean/create_test.go
+++ b/drivers/digitalocean/create_test.go
@@ -147,7 +147,7 @@ func testInstance(instance *autoscaler.Instance) func(t *testing.T) {
 		if got, want := instance.ID, "3164494"; got != want {
 			t.Errorf("Want droplet ID %v, got %v", want, got)
 		}
-		if got, want := instance.Image, "docker-16-04"; got != want {
+		if got, want := instance.Image, "docker-18-04"; got != want {
 			t.Errorf("Want droplet Image %v, got %v", want, got)
 		}
 		if got, want := instance.Name, "example.com"; got != want {

--- a/drivers/digitalocean/option_test.go
+++ b/drivers/digitalocean/option_test.go
@@ -8,7 +8,7 @@ import "testing"
 
 func TestOptions(t *testing.T) {
 	p := New(
-		WithImage("ubuntu-16-04-x64"),
+		WithImage("ubuntu-18-04-x64"),
 		WithRegion("nyc3"),
 		WithSize("s-8vcpu-32gb"),
 		WithSSHKey("58:8e:30:66:fc:e2:ff:ad:4f:6f:02:4b:af:28:0d:c7"),
@@ -16,7 +16,7 @@ func TestOptions(t *testing.T) {
 		WithToken("77e027c7447f468068a7d4fea41e7149a75a94088082c66fcf555de3977f69d3"),
 	).(*provider)
 
-	if got, want := p.image, "ubuntu-16-04-x64"; got != want {
+	if got, want := p.image, "ubuntu-18-04-x64"; got != want {
 		t.Errorf("Want image %q, got %q", want, got)
 	}
 	if got, want := p.region, "nyc3"; got != want {

--- a/drivers/digitalocean/provider.go
+++ b/drivers/digitalocean/provider.go
@@ -41,7 +41,7 @@ func New(opts ...Option) autoscaler.Provider {
 		p.size = "s-2vcpu-4gb"
 	}
 	if p.image == "" {
-		p.image = "docker-16-04"
+		p.image = "docker-18-04"
 	}
 	if p.userdata == nil {
 		p.userdata = userdataT

--- a/drivers/digitalocean/provider_test.go
+++ b/drivers/digitalocean/provider_test.go
@@ -8,7 +8,7 @@ import "testing"
 
 func TestDefaults(t *testing.T) {
 	p := New().(*provider)
-	if got, want := p.image, "docker-16-04"; got != want {
+	if got, want := p.image, "docker-18-04"; got != want {
 		t.Errorf("Want image %q, got %q", want, got)
 	}
 	if got, want := p.region, "nyc1"; got != want {

--- a/server/servers_test.go
+++ b/server/servers_test.go
@@ -176,7 +176,7 @@ func TestHandleServerDelete(t *testing.T) {
 
 	server := &autoscaler.Server{
 		Name:   "i-5203422c",
-		Image:  "docker-16-04",
+		Image:  "docker-18-04",
 		Region: "nyc1",
 		Size:   "s-1vcpu-1gb",
 	}
@@ -233,7 +233,7 @@ func TestHandleServerDeleteFailure(t *testing.T) {
 
 	server := &autoscaler.Server{
 		Name:   "i-5203422c",
-		Image:  "docker-16-04",
+		Image:  "docker-18-04",
 		Region: "nyc1",
 		Size:   "s-1vcpu-1gb",
 	}
@@ -270,7 +270,7 @@ func TestHandleServerDeleteErrorState(t *testing.T) {
 		ID:     "",
 		State:  autoscaler.StateError,
 		Name:   "i-5203422c",
-		Image:  "docker-16-04",
+		Image:  "docker-18-04",
 		Region: "nyc1",
 		Size:   "s-1vcpu-1gb",
 	}
@@ -299,7 +299,7 @@ func TestHandleServerForceDeleteErrorState(t *testing.T) {
 		ID:     "i-5203422c",
 		State:  autoscaler.StateError,
 		Name:   "i-5203422c",
-		Image:  "docker-16-04",
+		Image:  "docker-18-04",
 		Region: "nyc1",
 		Size:   "s-1vcpu-1gb",
 	}


### PR DESCRIPTION
<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->
The `docker-16-04` image no longer exists on DigitalOcean, making the autoscaler to fail with the following message:

```
2019-02-20T12:48:40Z |ERRO| cannot create instance error="POST https://api.digitalocean.com/v2/droplets: 422 You specified an invalid image for Droplet creation." id=HxHZXzMLR03eUj25 image=docker-16-04 name=agent-9gyr9yxS region=nyc1 size=s-2vcpu-4gb
```

This PR updates the default image to `docker-18-04`.