### PR TITLE
Fixed issue where the DRONE_DIGITALOCEAN_IMAGE environment variable would not be used.

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -209,6 +209,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 	case c.DigitalOcean.Token != "":
 		return digitalocean.New(
 			digitalocean.WithSSHKey(c.DigitalOcean.SSHKey),
+			digitalocean.WithImage(c.DigitalOcean.Image),
 			digitalocean.WithRegion(c.DigitalOcean.Region),
 			digitalocean.WithSize(c.DigitalOcean.Size),
 			digitalocean.WithUserDataFile(c.DigitalOcean.UserDataFile),


### PR DESCRIPTION
As reported here: https://discourse.drone.io/t/autoscaler-is-using-an-invalid-digital-ocean-image/3832, this fix the issue where `DRONE_DIGITALOCEAN_IMAGE` environment variable is ignored.