### PR TITLE
Implemented ErrInstanceNotFound in AWS driver

### DIFF
--- a/drivers/amazon/destroy_test.go
+++ b/drivers/amazon/destroy_test.go
@@ -60,3 +60,37 @@ func TestDestroyDeleteError(t *testing.T) {
 		t.Errorf("Expect error returned from aws")
 	}
 }
+
+func TestDestroyNotFound(t *testing.T) {
+	defer gock.Off()
+
+	os.Setenv("AWS_ACCESS_KEY_ID", "your_access_key_id")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "your_secret_access_key")
+	defer func() {
+		os.Unsetenv("AWS_ACCESS_KEY_ID")
+		os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	}()
+
+	gock.New("https://ec2.us-east-1.amazonaws.com").
+		Post("/").
+		Reply(400).
+		BodyString(`<Response><Errors><Error><Code>InvalidInstanceID.NotFound</Code><Message>The instance ID 'i-1a2b3c4d' does not exist</Message></Error></Errors><RequestID>ea966190-f9aa-478e-9ede-example</RequestID></Response>`)
+
+	mockContext := context.TODO()
+	mockInstance := &autoscaler.Instance{
+		ID: "i-1234567890abcdef0",
+	}
+
+	p := New(
+		WithRegion("us-east-1"),
+	).(*provider)
+	p.retries = 1
+
+	err := p.Destroy(mockContext, mockInstance)
+	if err == nil {
+		t.Errorf("Expect error returned from aws")
+	}
+	if err != autoscaler.ErrInstanceNotFound {
+		t.Errorf("Expect instance not found returned from aws")
+	}
+}

--- a/engine/reaper.go
+++ b/engine/reaper.go
@@ -96,7 +96,6 @@ func (r *reaper) reap(ctx context.Context, server *autoscaler.Server) error {
 
 		err := r.provider.Destroy(ctx, in)
 		// TODO implement ErrInstanceNotFound in Google driver
-		// TODO implement ErrInstanceNotFound in Amazon driver
 		// TODO implement ErrInstanceNotFound in Hetzner driver
 		// TODO implement ErrInstanceNotFound in Packet driver
 		if err == autoscaler.ErrInstanceNotFound {


### PR DESCRIPTION
Handling AWS instances not found when attempting to destroy. Implemented so that the reaper will clear out error'ed AWS instances.