### PR TITLE
fix: removing hardcoded DNS settings

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ steps:
   image: golang
   commands:
   - go get -u github.com/golang/dep/cmd/dep
-  - dep ensure -v
+  - dep ensure
   - go test -v -cover ./...
 
 - name: test_postgres

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ steps:
   image: golang
   commands:
   - go get -u github.com/golang/dep/cmd/dep
-  - dep ensure
+  - dep ensure -v
   - go test -v -cover ./...
 
 - name: test_postgres

--- a/drivers/internal/userdata/userdata.go
+++ b/drivers/internal/userdata/userdata.go
@@ -56,7 +56,6 @@ write_files:
   - path: /etc/docker/daemon.json
     content: |
       {
-        "dns": [ "8.8.8.8", "8.8.4.4" ],
         "hosts": [ "0.0.0.0:2376", "unix:///var/run/docker.sock" ],
         "tls": true,
         "tlsverify": true,


### PR DESCRIPTION
This removes the hardcoded DNS override for the Docker daemon and instead uses the default Docker settings for how to retrieve DNS: https://docs.docker.com/config/containers/container-networking/

If Docker cannot retrieve the host DNS settings it defaults back to Google DNS so this should not be a breaking change. I have tested this with AWS and verified it uses the host DNS as expected.


Found this same DNS setting in the Digital Ocean userdata, but was not sure if you wanted to remove that since I have no way to test that provider. After looking over this file: https://github.com/drone/autoscaler/blob/master/drivers/digitalocean/userdata.go I was not sure why Digital Ocean had it's own userdata, the only difference appears to be not installing Docker. Let me know if you want me to update this userdata also or point it to the shared one in this PR and I can update that.

@tboerger, @bradrydzewski mentioned you might want to look over this.