### PR TITLE
Let Hetzner decide which datacenter to choose

### DIFF
--- a/drivers/hetznercloud/create.go
+++ b/drivers/hetznercloud/create.go
@@ -35,9 +35,6 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		Image: &hcloud.Image{
 			Name: p.image,
 		},
-		Datacenter: &hcloud.Datacenter{
-			Name: p.datacenter,
-		},
 		SSHKeys: []*hcloud.SSHKey{
 			{
 				ID: p.key,
@@ -45,8 +42,18 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		},
 	}
 
+	datacenter := "unknown"
+
+	if p.datacenter != "" {
+		req.Datacenter = &hcloud.Datacenter{
+			Name: p.datacenter,
+		}
+
+		datacenter = p.datacenter
+	}
+
 	logger := log.Ctx(ctx).With().
-		Str("datacenter", req.Datacenter.Name).
+		Str("datacenter", datacenter).
 		Str("image", req.Image.Name).
 		Str("serverType", req.ServerType.Name).
 		Str("name", req.Name).
@@ -73,7 +80,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		Name:     resp.Server.Name,
 		Address:  resp.Server.PublicNet.IPv4.IP.String(),
 		Size:     req.ServerType.Name,
-		Region:   req.Datacenter.Name,
+		Region:   datacenter,
 		Image:    req.Image.Name,
 	}, nil
 }

--- a/drivers/hetznercloud/create_test.go
+++ b/drivers/hetznercloud/create_test.go
@@ -66,7 +66,7 @@ func testInstance(instance *autoscaler.Instance) func(t *testing.T) {
 		if got, want := instance.Name, "test"; got != want {
 			t.Errorf("Want instance Name %v, got %v", want, got)
 		}
-		if got, want := instance.Region, "nbg1-dc3"; got != want {
+		if got, want := instance.Region, "unknown"; got != want {
 			t.Errorf("Want instance Region %v, got %v", want, got)
 		}
 		if got, want := instance.Provider, autoscaler.ProviderHetznerCloud; got != want {

--- a/drivers/hetznercloud/provider.go
+++ b/drivers/hetznercloud/provider.go
@@ -34,9 +34,6 @@ func New(opts ...Option) autoscaler.Provider {
 	for _, opt := range opts {
 		opt(p)
 	}
-	if p.datacenter == "" {
-		p.datacenter = "nbg1-dc3"
-	}
 	if p.serverType == "" {
 		p.serverType = "cx11"
 	}

--- a/drivers/hetznercloud/provider_test.go
+++ b/drivers/hetznercloud/provider_test.go
@@ -11,7 +11,7 @@ func TestDefaults(t *testing.T) {
 	if got, want := p.image, "ubuntu-16.04"; got != want {
 		t.Errorf("Want image %q, got %q", want, got)
 	}
-	if got, want := p.datacenter, "nbg1-dc3"; got != want {
+	if got, want := p.datacenter, ""; got != want {
 		t.Errorf("Want datacenter %q, got %q", want, got)
 	}
 	if got, want := p.serverType, "cx11"; got != want {


### PR DESCRIPTION
We are running quite often into an error like `we are unable to provision servers for this location, try with a different location or try later (resource_unavailable)`, the Hetzner Cloud support told me that we should be able to not provide any datacenter and Hetzner Cloud will automatically decide which datacenter could be taken for the new instance.

With this patch I have made the datacenter option optionally. With my
current tests it seems to be running fine as far as I can say.