### PR TITLE
Failed to ping server fix

### DIFF
--- a/engine/pinger.go
+++ b/engine/pinger.go
@@ -98,6 +98,6 @@ func (p *pinger) ping(ctx context.Context, server *autoscaler.Server) error {
 
 	server.Error = "Failed to ping the server"
 	server.Stopped = time.Now().Unix()
-	server.State = autoscaler.StateStopped
+	server.State = autoscaler.StateError
 	return p.servers.Update(ctx, server)
 }

--- a/engine/pinger.go
+++ b/engine/pinger.go
@@ -98,5 +98,6 @@ func (p *pinger) ping(ctx context.Context, server *autoscaler.Server) error {
 
 	server.Error = "Failed to ping the server"
 	server.Stopped = time.Now().Unix()
+	server.State = autoscaler.StateStopped
 	return p.servers.Update(ctx, server)
 }


### PR DESCRIPTION
The server will still be in a running state after ping failure, and the autoscaler will keep trying to reprovision it. The stopped time is set, but the state is not updated. This puts it in a stopped state, similar to https://github.com/drone/autoscaler/blob/master/engine/collect.go#L108-L109 and https://github.com/drone/autoscaler/blob/master/engine/reaper.go#L121-L122
