### PR TITLE
Replaced APIClient with Client, added Close()s

### DIFF
--- a/engine/collect.go
+++ b/engine/collect.go
@@ -84,6 +84,7 @@ func (c *collector) collect(ctx context.Context, server *autoscaler.Server) erro
 	if err != nil {
 		return err
 	}
+	
 	timeout := time.Hour * 60
 	err = client.ContainerStop(ctx, "agent", &timeout)
 	if err != nil {

--- a/engine/collect.go
+++ b/engine/collect.go
@@ -80,10 +80,10 @@ func (c *collector) collect(ctx context.Context, server *autoscaler.Server) erro
 	}
 
 	client, err := c.client(server)
+	defer client.Close()
 	if err != nil {
 		return err
 	}
-
 	timeout := time.Hour * 60
 	err = client.ContainerStop(ctx, "agent", &timeout)
 	if err != nil {

--- a/engine/collect_test.go
+++ b/engine/collect_test.go
@@ -39,7 +39,7 @@ func TestCollect(t *testing.T) {
 	c := collector{
 		servers:  store,
 		provider: provider,
-		client: func(*autoscaler.Server) (docker.APIClient, error) {
+		client: func(*autoscaler.Server) (*docker.Client, error) {
 			return client, nil
 		},
 	}
@@ -78,7 +78,7 @@ func TestCollect_DockerStopError(t *testing.T) {
 	c := collector{
 		servers:  store,
 		provider: provider,
-		client: func(*autoscaler.Server) (docker.APIClient, error) {
+		client: func(*autoscaler.Server) (*docker.Client, error) {
 			return client, nil
 		},
 	}
@@ -120,7 +120,7 @@ func TestCollect_ServerDestroyError(t *testing.T) {
 	c := collector{
 		servers:  store,
 		provider: provider,
-		client: func(*autoscaler.Server) (docker.APIClient, error) {
+		client: func(*autoscaler.Server) (*docker.Client, error) {
 			return client, nil
 		},
 	}

--- a/engine/docker.go
+++ b/engine/docker.go
@@ -18,11 +18,11 @@ import (
 // clientFunc defines a builder funciton used to build and return
 // the docker client from a Server. This is primarily used for
 // mock unit testing.
-type clientFunc func(*autoscaler.Server) (docker.APIClient, error)
+type clientFunc func(*autoscaler.Server) (*docker.Client, error)
 
 // newDockerClient returns a new Docker client configured for the
 // Server host and certificate chain.
-func newDockerClient(server *autoscaler.Server) (docker.APIClient, error) {
+func newDockerClient(server *autoscaler.Server) (*docker.Client, error) {
 	tlsCert, err := tls.X509KeyPair(server.TLSCert, server.TLSKey)
 	if err != nil {
 		return nil, err

--- a/engine/install.go
+++ b/engine/install.go
@@ -90,6 +90,7 @@ func (i *installer) install(ctx context.Context, instance *autoscaler.Server) er
 		Logger()
 
 	client, err := i.client(instance)
+	defer client.Close()
 	if err != nil {
 		logger.Error().Err(err).
 			Msg("cannot create docker client")
@@ -252,7 +253,7 @@ poller:
 	return i.servers.Update(ctx, instance)
 }
 
-func (i *installer) setupWatchtower(ctx context.Context, client docker.APIClient) error {
+func (i *installer) setupWatchtower(ctx context.Context, client *docker.Client) error {
 	vols := []string{"/var/run/docker.sock:/var/run/docker.sock"}
 	res, err := client.ContainerCreate(ctx,
 		&container.Config{
@@ -278,7 +279,7 @@ func (i *installer) setupWatchtower(ctx context.Context, client docker.APIClient
 	return client.ContainerStart(ctx, res.ID, types.ContainerStartOptions{})
 }
 
-func (i *installer) setupGarbageCollectoer(ctx context.Context, client docker.APIClient) error {
+func (i *installer) setupGarbageCollectoer(ctx context.Context, client *docker.Client) error {
 	vols := []string{"/var/run/docker.sock:/var/run/docker.sock"}
 	envs := []string{
 		fmt.Sprintf("GC_CACHE=%s", i.gcCache),

--- a/engine/pinger.go
+++ b/engine/pinger.go
@@ -60,6 +60,7 @@ func (p *pinger) ping(ctx context.Context, server *autoscaler.Server) error {
 		Logger()
 
 	client, err := p.client(server)
+	defer client.Close()
 	if err != nil {
 		logger.Error().Err(err).
 			Msg("cannot create docker client")


### PR DESCRIPTION
As mentioned [here](https://github.com/drone/autoscaler/pull/42#issuecomment-517486281,) I've seen connection issues with the autoscaler. `netstat -an | grep 2376` will show multiple `ESTABLISHED` connections from the autoscaler after some time. 

Digging through the docker-go repo I ran into [this](https://github.com/docker/go-docker/issues/16) and [this](https://github.com/golang/gddo/issues/623). I've applied a similar solution to what he did. `APIClient` doesn't seem to implement `Close`, so I've replaced it with `Client`, and added `defer client.Close()` whenever one is created. Pinger seems to work as before, and no more dangling `ESTABLISHED` connections are seen.