### PR TITLE
Add postgresql driver to main.go

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
 	_ "github.com/joho/godotenv/autoload"
 	_ "github.com/mattn/go-sqlite3"
 )

--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -36,8 +36,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
 	_ "github.com/joho/godotenv/autoload"
+	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 )
 


### PR DESCRIPTION
I don't really know goloang, so I'm not sure if that's the only thing required for a fix, but it seems to be.

It has been brought up on June 3 in the chat already and never been fixed (although it is mentioned in the documentation as supported). I want to get the ball rolling on this issue.
> @bradrydzewski getting an unexpected error with the drone autoscaler:
> ```
> {"level":"fatal","error":"sql: unknown driver \"postgres\" (forgotten import?)","time":"2019-06-03T20:54:46Z","message":"Cannot establish database connection"}
> ```