### PR TITLE
Pull Garbage Collector image

### DIFF
--- a/engine/install.go
+++ b/engine/install.go
@@ -303,6 +303,7 @@ func (i *installer) setupWatchtower(ctx context.Context, client docker.APIClient
 }
 
 func (i *installer) setupGarbageCollector(ctx context.Context, client docker.APIClient) error {
+	logger := log.Ctx(ctx)
 	vols := []string{"/var/run/docker.sock:/var/run/docker.sock"}
 	envs := []string{
 		fmt.Sprintf("GC_CACHE=%s", i.gcCache),


### PR DESCRIPTION
When enabling the Garbage Collector for the agent, it is unable to create the container because the image is missing. I've added an image pull and fixed a typo in the function name.