### PR TITLE
Ignore error state on planner

### DIFF
--- a/engine/planner.go
+++ b/engine/planner.go
@@ -242,6 +242,8 @@ func (p *planner) capacity(ctx context.Context) (capacity, count int, err error)
 		switch server.State {
 		case autoscaler.StateStopped:
 			// ignore state
+		case autoscaler.StateError:
+			// ignore state
 		default:
 			count++
 			capacity += server.Capacity


### PR DESCRIPTION
I'm not 100% sure if this would be the best way to go. 

Currently an instance will be placed in an error state if there is no spot capacity available in AWS for example. These will count towards the autoscaler's capacity, and won't be destroyed until the reaper gets rid of them in the next hour. I made a small change so that instances in error state won't count just like stopped instances. 

Another option would be to move the reaper interval to an environment variable, so that it can be run every 10 minutes for example. While it is true that this is infrequent, clearing these every hour could mean a queue building for an hour until they're cleared.