### PR TITLE
Reaper interval environment variable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,7 +66,6 @@ type (
 		}
 
 		Reaper struct {
-			Enabled  bool          `envconfig:"DRONE_ENABLE_REAPER" default:"false"`
 			Interval time.Duration `envconfig:"DRONE_REAPER_INTERVAL" default:"1h"`
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,11 @@ type (
 			Cache    string        `envconfig:"DRONE_GC_CACHE" default:"10gb"`
 		}
 
+		Reaper struct {
+			Enabled  bool          `envconfig:"DRONE_ENABLE_REAPER" default:"false"`
+			Interval time.Duration `envconfig:"DRONE_REAPER_INTERVAL" default:"1h"`
+		}
+
 		Watchtower struct {
 			Enabled  bool          `envconfig:"DRONE_WATCHTOWER_ENABLED"`
 			Image    string        `envconfig:"DRONE_WATCHTOWER_IMAGE" default:"webhippie/watchtower"`

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -323,7 +323,6 @@ var jsonConfig = []byte(`{
 		"Cache": "10gb"
 	},
 	"Reaper": {
-		"Enabled": false,
 		"Interval": 3600000000000
 	}
 }`)

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -321,5 +321,9 @@ var jsonConfig = []byte(`{
 		"Image": "drone/gc",
 		"Interval": 1800000000000,
 		"Cache": "10gb"
+	},
+	"Reaper": {
+		"Enabled": false,
+		"Interval": 3600000000000
 	}
 }`)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -98,6 +98,7 @@ func New(
 		reaper: &reaper{
 			servers:  servers,
 			provider: provider,
+			interval: config.Reaper.Interval,
 		},
 	}
 }
@@ -256,9 +257,9 @@ func (e *engine) purge(ctx context.Context) {
 
 // runs the reaper process.
 func (e *engine) reap(ctx context.Context) {
-	// the reaper is run hourly since in general this
+	// by default, the reaper is run hourly since in general this
 	// should happen infrequently.
-	const interval = time.Hour
+	const interval = e.reaper.interval
 	for {
 		select {
 		case <-ctx.Done():

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -259,12 +259,11 @@ func (e *engine) purge(ctx context.Context) {
 func (e *engine) reap(ctx context.Context) {
 	// by default, the reaper is run hourly since in general this
 	// should happen infrequently.
-	const interval = e.reaper.interval
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(interval):
+		case <-time.After(e.reaper.interval):
 			e.reaper.Reap(ctx)
 		}
 	}

--- a/engine/reaper.go
+++ b/engine/reaper.go
@@ -40,6 +40,7 @@ type reaper struct {
 
 	servers  autoscaler.ServerStore
 	provider autoscaler.Provider
+	interval time.Duration
 }
 
 func (r *reaper) Reap(ctx context.Context) error {


### PR DESCRIPTION
Currently an instance will be placed in an error state if there is no spot capacity available in AWS for example. These will count towards the autoscaler's capacity, and won't be destroyed until the reaper gets rid of them in the next hour. I moved the reaper interval to an environment variable so that one can choose the frequency.
