### PR TITLE
Fixed issue where an unexisting instance could not be destroyed.

### DIFF
--- a/engine/collect.go
+++ b/engine/collect.go
@@ -96,7 +96,15 @@ func (c *collector) collect(ctx context.Context, server *autoscaler.Server) erro
 	}
 
 	err = c.provider.Destroy(ctx, in)
-	if err != nil {
+        if err == autoscaler.ErrInstanceNotFound {
+		logger.Info().
+			Str("state", "error").
+			Str("server", server.Name).
+			Msg("server no longer exists. nothing to destroy")
+
+		server.Stopped = time.Now().Unix()
+		server.State = autoscaler.StateStopped
+        } else if err != nil {
 		logger.Error().
 			Str("server", server.Name).
 			Msg("failed to destroy server")


### PR DESCRIPTION
I'm using the autoscaler with DigitalOcean.  The autoscaler went into a state where the server count was not reflecting the reality.  For example, when no Droplet existed on my account, the autoscaler was reporting something different:

```
9:12AM DBG check capacity id=Bjc93TuZjLNlUqoc max-pool=4 min-pool=0 pending-builds=0 running-builds=0 server-buffer=0 server-capacity=4 server-count=2
```
Attempting to remove these servers with the cli via `server destroy` command results with the following error on the autoscaler:

```
11:03AM DBG destroying server server=agent-p8clg4bK
11:03AM WRN cannot stop the agent error="Cannot connect to the Docker daemon at https://134.209.214.159:2376. Is the docker daemon running?" server=agent-p8clg4bK
11:03AM WRN droplet does not exist error="GET https://api.digitalocean.com/v2/droplets/141608491: 404 The resource you were accessing could not be found." image=docker-18-04 name=agent-p8clg4bK region=nyc1 size=s-4vcpu-8gb
11:03AM ERR failed to destroy server server=agent-p8clg4bK
```

This PR fixes the removal of these servers by looking at the error, similarily to what is done in `engine/reaper.go`.