### PR TITLE
Implement ErrInstanceNotFound fir HetznerCloud

### DIFF
--- a/drivers/hetznercloud/destroy.go
+++ b/drivers/hetznercloud/destroy.go
@@ -29,7 +29,14 @@ func (p *provider) Destroy(ctx context.Context, instance *autoscaler.Instance) e
 	logger.Debugln("deleting instance")
 
 	_, err = p.client.Server.Delete(ctx, &hcloud.Server{ID: id})
+
 	if err != nil {
+		if err.Error() == "hcloud: server responded with status code 404" {
+			logger.WithError(err).
+				Debugln("instance does not exist")
+			return autoscaler.ErrInstanceNotFound
+		}
+
 		logger.WithError(err).
 			Errorln("deleting instance failed")
 		return err


### PR DESCRIPTION
Currently the Hetzner Cloud driver does not implement the
ErrInstanceNotFound error if a server does not exist anymore, I have
added a test and integrated the required functionality.
