### PR TITLE
support for custom networks in google cloud

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -229,6 +229,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			google.WithMachineType(c.Google.MachineType),
 			google.WithLabels(c.Google.Labels),
 			google.WithNetwork(c.Google.Network),
+			google.WithSubnetwork(c.Google.Subnetwork),
 			google.WithProject(c.Google.Project),
 			google.WithTags(c.Google.Tags...),
 			google.WithUserData(c.Google.UserData),

--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,7 @@ type (
 			MachineType  string            `envconfig:"DRONE_GOOGLE_MACHINE_TYPE"`
 			MachineImage string            `envconfig:"DRONE_GOOGLE_MACHINE_IMAGE"`
 			Network      string            `envconfig:"DRONE_GOOGLE_NETWORK"`
+			Subnetwork   string            `envconfig:"DRONE_GOOGLE_SUBNETWORK"`
 			Labels       map[string]string `envconfig:"DRONE_GOOGLE_LABELS"`
 			Scopes       string            `envconfig:"DRONE_GOOGLE_SCOPES"`
 			DiskSize     int64             `envconfig:"DRONE_GOOGLE_DISK_SIZE"`

--- a/drivers/google/create.go
+++ b/drivers/google/create.go
@@ -72,6 +72,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		NetworkInterfaces: []*compute.NetworkInterface{
 			{
 				Network: p.network,
+				Subnetwork: p.subnetwork,
 				AccessConfigs: []*compute.AccessConfig{
 					{
 						Name: "External NAT",

--- a/drivers/google/option.go
+++ b/drivers/google/option.go
@@ -71,6 +71,13 @@ func WithNetwork(network string) Option {
 	}
 }
 
+// WithSubNetwork returns an option to set the subnetwork.
+func WithSubnetwork(subnetwork string) Option {
+	return func(p *provider) {
+		p.subnetwork = subnetwork
+	}
+}
+
 // WithProject returns an option to set the project.
 func WithProject(project string) Option {
 	return func(p *provider) {

--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -74,6 +74,9 @@ func New(opts ...Option) (autoscaler.Provider, error) {
 	if p.network == "" {
 		p.network = "global/networks/default"
 	}
+	if p.subnetwork == "" {
+		p.subnetwork = "subnetworks/default"
+	}
 	if p.userdata == nil {
 		p.userdata = userdata.T
 	}

--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -75,9 +75,6 @@ func New(opts ...Option) (autoscaler.Provider, error) {
 	if p.network == "" {
 		p.network = "global/networks/default"
 	}
-	if p.subnetwork == "" {
-		p.subnetwork = "subnetworks/default"
-	}
 	if p.userdata == nil {
 		p.userdata = userdata.T
 	}

--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -35,17 +35,18 @@ var (
 type provider struct {
 	init sync.Once
 
-	diskSize int64
-	diskType string
-	image    string
-	labels   map[string]string
-	network  string
-	project  string
-	scopes   []string
-	size     string
-	tags     []string
-	zone     string
-	userdata *template.Template
+	diskSize   int64
+	diskType   string
+	image      string
+	labels     map[string]string
+	network    string
+	subnetwork string
+	project    string
+	scopes     []string
+	size       string
+	tags       []string
+	zone       string
+	userdata   *template.Template
 
 	service *compute.Service
 }


### PR DESCRIPTION
With existing code, GCP instances are not spawned if custom networks are specified for GCP instances. This PR is to add support for custom networks. Thx

<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->