### PR TITLE
change default interal to 1m as stated in the doc

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import "time"
 type (
 	// Config stores the configuration settings.
 	Config struct {
-		Interval       time.Duration `default:"5m"`
+		Interval       time.Duration `default:"1m"`
 		CapacityBuffer int           `default:"0" split_words:"true"`
 
 		Slack struct {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -19,7 +19,7 @@ func TestDefaults(t *testing.T) {
 	if got, want := conf.Logs.Debug, true; got != want {
 		t.Errorf("Want default DRONE_LOGS_DEBUG of %v, got %v", want, got)
 	}
-	if got, want := conf.Interval, time.Minute*5; got != want {
+	if got, want := conf.Interval, time.Minute; got != want {
 		t.Errorf("Want default DRONE_INTERVAL of %s, got %s", want, got)
 	}
 	if got, want := conf.CapacityBuffer, 0; got != want {


### PR DESCRIPTION
Hi,

This PR changes the default interval to 1m as stated in the doc here https://autoscale.drone.io/reference/drone-interval/

If you prefer to keep it at 5m, then the doc should be changed.

Cheers 

<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->