### PR TITLE
Add Volume IOPS configuration for AWS io1 volumes

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -300,6 +300,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			amazon.WithUserDataFile(c.Amazon.UserDataFile),
 			amazon.WithVolumeSize(c.Amazon.VolumeSize),
 			amazon.WithVolumeType(c.Amazon.VolumeType),
+			amazon.WithVolumeIops(c.Amazon.VolumeIops),
 			amazon.WithIamProfileArn(c.Amazon.IamProfileArn),
 			amazon.WithMarketType(c.Amazon.MarketType),
 		), nil

--- a/config/config.go
+++ b/config/config.go
@@ -124,6 +124,7 @@ type (
 			UserDataFile  string `envconfig:"DRONE_AMAZON_USERDATA_FILE"`
 			VolumeSize    int64  `envconfig:"DRONE_AMAZON_VOLUME_SIZE"`
 			VolumeType    string `envconfig:"DRONE_AMAZON_VOLUME_TYPE"`
+			VolumeIops    int64  `envconfig:"DRONE_AMAZON_VOLUME_IOPS"`
 			IamProfileArn string `envconfig:"DRONE_AMAZON_IAM_PROFILE_ARN"`
 			MarketType    string `envconfig:"DRONE_AMAZON_MARKET_TYPE"`
 		}

--- a/drivers/amazon/create.go
+++ b/drivers/amazon/create.go
@@ -84,6 +84,12 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		},
 	}
 
+	if p.volumeType == "io1" {
+		for _, blockDeviceMapping := range in.BlockDeviceMappings {
+			blockDeviceMapping.Ebs.Iops = aws.Int64(p.volumeIops)
+		}
+	}
+
 	logger := logger.FromContext(ctx).
 		WithField("region", p.region).
 		WithField("image", p.image).

--- a/drivers/amazon/option.go
+++ b/drivers/amazon/option.go
@@ -122,6 +122,13 @@ func WithVolumeType(t string) Option {
 	}
 }
 
+// WithVolumeIops returns an option to set the volume iops.
+func WithVolumeIops(i int64) Option {
+	return func(p *provider) {
+		p.volumeIops = i
+	}
+}
+
 // WithIamProfileArn returns an option to set the iam profile arn.
 func WithIamProfileArn(t string) Option {
 	return func(p *provider) {

--- a/drivers/amazon/provider.go
+++ b/drivers/amazon/provider.go
@@ -22,6 +22,7 @@ type provider struct {
 	deviceName    string
 	volumeSize    int64
 	volumeType    string
+	volumeIops    int64
 	retries       int
 	key           string
 	region        string
@@ -69,6 +70,9 @@ func New(opts ...Option) autoscaler.Provider {
 	}
 	if p.volumeType == "" {
 		p.volumeType = "gp2"
+	}
+	if p.volumeType == "io1" && p.volumeIops == 0 {
+		p.volumeIops = 100
 	}
 	if p.userdata == nil {
 		p.userdata = userdata.T


### PR DESCRIPTION
This pull request implements configuring IOPS for AWS Provisioned IOPS EBS volumes (io1). 

Although autoscaler currently supports configuring EBS volume type with DRONE_AMAZON_VOLUME_TYPE, setting this parameter to `io1` causes agent creation to fail. This is because AWS requires that IOPS be set for `io1` volumes.

This PR adds a configuration `DRONE_AMAZON_VOLUME_IOPS` for configuring IOPS when using `io1` EBS volumes to fix failing agent creation.