### PR TITLE
[GCP] Insufficient scope fix

### DIFF
--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -87,7 +87,7 @@ func New(opts ...Option) (autoscaler.Provider, error) {
 		p.scopes = defaultScopes
 	}
 	if p.service == nil {
-		client, err := google.DefaultClient(oauth2.NoContext, p.scopes...)
+		client, err := google.DefaultClient(oauth2.NoContext, compute.ComputeScope)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This fixes an issue with GCP autoscalers not having the right scope/permission even with `Project Owner` role assigned to the service account.