### PR TITLE
Adding an option to use a private IP with Google Cloud

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -231,6 +231,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			google.WithLabels(c.Google.Labels),
 			google.WithNetwork(c.Google.Network),
 			google.WithSubnetwork(c.Google.Subnetwork),
+			google.WithPrivateIP(c.Google.PrivateIP),
 			google.WithProject(c.Google.Project),
 			google.WithTags(c.Google.Tags...),
 			google.WithUserData(c.Google.UserData),

--- a/config/config.go
+++ b/config/config.go
@@ -155,6 +155,7 @@ type (
 			DiskSize     int64             `envconfig:"DRONE_GOOGLE_DISK_SIZE"`
 			DiskType     string            `envconfig:"DRONE_GOOGLE_DISK_TYPE"`
 			Project      string            `envconfig:"DRONE_GOOGLE_PROJECT"`
+			PrivateIP    bool              `split_words:"true"`
 			Tags         []string          `envconfig:"DRONE_GOOGLE_TAGS"`
 			UserData     string            `envconfig:"DRONE_GOOGLE_USERDATA"`
 			UserDataFile string            `envconfig:"DRONE_GOOGLE_USERDATA_FILE"`

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -106,6 +106,7 @@ func TestLoad(t *testing.T) {
 		"DRONE_GOOGLE_DISK_TYPE":           "pd-standard",
 		"DRONE_GOOGLE_NETWORK":             "default",
 		"DRONE_GOOGLE_SUBNETWORK":          "",
+		"DRONE_GOOGLE_PRIVATE_IP":          "false",
 		"DRONE_GOOGLE_PREEMPTIBLE":         "true",
 		"DRONE_GOOGLE_SCOPES":              "devstorage.read_only",
 		"DRONE_GOOGLE_DISK_SIZE":           "10",

--- a/drivers/google/create.go
+++ b/drivers/google/create.go
@@ -47,7 +47,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		},
 	}
 
-	if !p.private {
+	if !p.privateIP {
 		networkConfig = publicIPConfig
 	}
 

--- a/drivers/google/create.go
+++ b/drivers/google/create.go
@@ -40,15 +40,13 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 
 	networkConfig := []*compute.AccessConfig{}
 
-	publicIPConfig := []*compute.AccessConfig{
-		{
-			Name: "External NAT",
-			Type: "ONE_TO_ONE_NAT",
-		},
-	}
-
 	if !p.privateIP {
-		networkConfig = publicIPConfig
+		networkConfig = []*compute.AccessConfig{
+			{
+				Name: "External NAT",
+				Type: "ONE_TO_ONE_NAT",
+			},
+		}
 	}
 
 	in := &compute.Instance{

--- a/drivers/google/create.go
+++ b/drivers/google/create.go
@@ -38,6 +38,19 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 
 	logger.Debugln("instance insert")
 
+	networkConfig := []*compute.AccessConfig{}
+
+	publicIPConfig := []*compute.AccessConfig{
+		{
+			Name: "External NAT",
+			Type: "ONE_TO_ONE_NAT",
+		},
+	}
+
+	if !p.private {
+		networkConfig = publicIPConfig
+	}
+
 	in := &compute.Instance{
 		Name:           name,
 		Zone:           fmt.Sprintf("projects/%s/zones/%s", p.project, p.zone),
@@ -71,14 +84,9 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		CanIpForward: false,
 		NetworkInterfaces: []*compute.NetworkInterface{
 			{
-				Network: p.network,
-				Subnetwork: p.subnetwork,
-				AccessConfigs: []*compute.AccessConfig{
-					{
-						Name: "External NAT",
-						Type: "ONE_TO_ONE_NAT",
-					},
-				},
+				Network:       p.network,
+				Subnetwork:    p.subnetwork,
+				AccessConfigs: networkConfig,
 			},
 		},
 		Labels: p.labels,

--- a/drivers/google/option.go
+++ b/drivers/google/option.go
@@ -78,6 +78,13 @@ func WithSubnetwork(subnetwork string) Option {
 	}
 }
 
+// WithPrivateIP returns an option to set the private IP address.
+func WithPrivateIP(private bool) Option {
+	return func(p *provider) {
+		p.privateIP = private
+	}
+}
+
 // WithProject returns an option to set the project.
 func WithProject(project string) Option {
 	return func(p *provider) {

--- a/drivers/google/option_test.go
+++ b/drivers/google/option_test.go
@@ -17,6 +17,7 @@ func TestOptions(t *testing.T) {
 		WithMachineImage("ubuntu-1604-lts"),
 		WithMachineType("c3.large"),
 		WithNetwork("global/defaults/foo"),
+		WithPrivateIP(false),
 		WithProject("my-project"),
 		WithTags("drone", "agent"),
 		WithZone("us-central1-f"),
@@ -38,6 +39,9 @@ func TestOptions(t *testing.T) {
 	}
 	if got, want := p.network, "global/defaults/foo"; got != want {
 		t.Errorf("Want network %q, got %q", want, got)
+	}
+	if got, want := p.privateIP, false; got != want {
+		t.Errorf("Want %v privateIP, got %v", want, got)
 	}
 	if got, want := p.project, "my-project"; got != want {
 		t.Errorf("Want project %q, got %q", want, got)

--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -43,6 +43,7 @@ type provider struct {
 	labels     map[string]string
 	network    string
 	subnetwork string
+	privateIP  bool
 	project    string
 	scopes     []string
 	size       string


### PR DESCRIPTION
Hi All,

Attempting to add Google Private IP's as an option. Still learning go and not confident this is the correct way to approach the config. Happy to update as needed.

<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->