### PR TITLE
Configure Service Account name for GCP instances

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -232,6 +232,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			google.WithNetwork(c.Google.Network),
 			google.WithSubnetwork(c.Google.Subnetwork),
 			google.WithPrivateIP(c.Google.PrivateIP),
+			google.WithServiceAccountEmail(c.Google.ServiceAccountEmail),
 			google.WithProject(c.Google.Project),
 			google.WithTags(c.Google.Tags...),
 			google.WithUserData(c.Google.UserData),

--- a/config/config.go
+++ b/config/config.go
@@ -152,7 +152,7 @@ type (
 			Network             string            `envconfig:"DRONE_GOOGLE_NETWORK"`
 			Subnetwork          string            `envconfig:"DRONE_GOOGLE_SUBNETWORK"`
 			Labels              map[string]string `envconfig:"DRONE_GOOGLE_LABELS"`
-			Scopes       []string          `envconfig:"DRONE_GOOGLE_SCOPES"`
+			Scopes              []string          `envconfig:"DRONE_GOOGLE_SCOPES"`
 			ServiceAccountEmail string            `envconfig:"DRONE_GOOGLE_SERVICE_ACCOUNT_EMAIL"`
 			DiskSize            int64             `envconfig:"DRONE_GOOGLE_DISK_SIZE"`
 			DiskType            string            `envconfig:"DRONE_GOOGLE_DISK_TYPE"`

--- a/config/config.go
+++ b/config/config.go
@@ -147,20 +147,21 @@ type (
 		}
 
 		Google struct {
-			MachineType  string            `envconfig:"DRONE_GOOGLE_MACHINE_TYPE"`
-			MachineImage string            `envconfig:"DRONE_GOOGLE_MACHINE_IMAGE"`
-			Network      string            `envconfig:"DRONE_GOOGLE_NETWORK"`
-			Subnetwork   string            `envconfig:"DRONE_GOOGLE_SUBNETWORK"`
-			Labels       map[string]string `envconfig:"DRONE_GOOGLE_LABELS"`
+			MachineType         string            `envconfig:"DRONE_GOOGLE_MACHINE_TYPE"`
+			MachineImage        string            `envconfig:"DRONE_GOOGLE_MACHINE_IMAGE"`
+			Network             string            `envconfig:"DRONE_GOOGLE_NETWORK"`
+			Subnetwork          string            `envconfig:"DRONE_GOOGLE_SUBNETWORK"`
+			Labels              map[string]string `envconfig:"DRONE_GOOGLE_LABELS"`
 			Scopes       []string          `envconfig:"DRONE_GOOGLE_SCOPES"`
-			DiskSize     int64             `envconfig:"DRONE_GOOGLE_DISK_SIZE"`
-			DiskType     string            `envconfig:"DRONE_GOOGLE_DISK_TYPE"`
-			Project      string            `envconfig:"DRONE_GOOGLE_PROJECT"`
-			PrivateIP    bool              `split_words:"true"`
-			Tags         []string          `envconfig:"DRONE_GOOGLE_TAGS"`
-			UserData     string            `envconfig:"DRONE_GOOGLE_USERDATA"`
-			UserDataFile string            `envconfig:"DRONE_GOOGLE_USERDATA_FILE"`
-			Zone         string            `envconfig:"DRONE_GOOGLE_ZONE"`
+			ServiceAccountEmail string            `envconfig:"DRONE_GOOGLE_SERVICE_ACCOUNT_EMAIL"`
+			DiskSize            int64             `envconfig:"DRONE_GOOGLE_DISK_SIZE"`
+			DiskType            string            `envconfig:"DRONE_GOOGLE_DISK_TYPE"`
+			Project             string            `envconfig:"DRONE_GOOGLE_PROJECT"`
+			PrivateIP           bool              `split_words:"true"`
+			Tags                []string          `envconfig:"DRONE_GOOGLE_TAGS"`
+			UserData            string            `envconfig:"DRONE_GOOGLE_USERDATA"`
+			UserDataFile        string            `envconfig:"DRONE_GOOGLE_USERDATA_FILE"`
+			Zone                string            `envconfig:"DRONE_GOOGLE_ZONE"`
 		}
 
 		HetznerCloud struct {

--- a/drivers/google/create.go
+++ b/drivers/google/create.go
@@ -128,13 +128,13 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 	}
 
 	instance := &autoscaler.Instance{
-		Provider: autoscaler.ProviderGoogle,
-		ID:       name,
-		Name:     opts.Name,
-		Image:    p.image,
-		Region:   p.zone,
-		Size:     p.size,
-		Address:  resp.NetworkInterfaces[0].AccessConfigs[0].NatIP,
+		Provider:            autoscaler.ProviderGoogle,
+		ID:                  name,
+		Name:                opts.Name,
+		Image:               p.image,
+		Region:              p.zone,
+		Size:                p.size,
+		Address:             resp.NetworkInterfaces[0].AccessConfigs[0].NatIP,
 		ServiceAccountEmail: p.serviceAccountEmail,
 	}
 

--- a/drivers/google/create.go
+++ b/drivers/google/create.go
@@ -97,7 +97,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		ServiceAccounts: []*compute.ServiceAccount{
 			{
 				Scopes: p.scopes,
-				Email:  "default",
+				Email:  p.serviceAccountEmail,
 			},
 		},
 	}
@@ -135,6 +135,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		Region:   p.zone,
 		Size:     p.size,
 		Address:  resp.NetworkInterfaces[0].AccessConfigs[0].NatIP,
+		ServiceAccountEmail: p.serviceAccountEmail,
 	}
 
 	logger.

--- a/drivers/google/create_test.go
+++ b/drivers/google/create_test.go
@@ -74,6 +74,9 @@ func TestCreate(t *testing.T) {
 	if want, got := instance.Size, "n1-standard-1"; got != want {
 		t.Errorf("Want instance Size %q, got %q", want, got)
 	}
+	if want, got := instance.ServiceAccountEmail, "default"; got != want {
+		t.Errorf("Want service account email  %q, got %q", want, got)
+	}
 }
 
 var insertInstanceMock = &compute.Instance{

--- a/drivers/google/option.go
+++ b/drivers/google/option.go
@@ -134,5 +134,12 @@ func WithZone(zone string) Option {
 func WithScopes(scopes ...string) Option {
 	return func(p *provider) {
 		p.scopes = scopes
+  }
+}
+
+// WithServiceAccountEmail returns an option to set the ServiceAccountEmail.
+func WithServiceAccountEmail(email string) Option {
+	return func(p *provider) {
+		p.serviceAccountEmail = email
 	}
 }

--- a/drivers/google/option.go
+++ b/drivers/google/option.go
@@ -134,7 +134,7 @@ func WithZone(zone string) Option {
 func WithScopes(scopes ...string) Option {
 	return func(p *provider) {
 		p.scopes = scopes
-  }
+	}
 }
 
 // WithServiceAccountEmail returns an option to set the ServiceAccountEmail.

--- a/drivers/google/option_test.go
+++ b/drivers/google/option_test.go
@@ -18,6 +18,7 @@ func TestOptions(t *testing.T) {
 		WithMachineType("c3.large"),
 		WithNetwork("global/defaults/foo"),
 		WithPrivateIP(false),
+		WithServiceAccountEmail("default"),
 		WithProject("my-project"),
 		WithTags("drone", "agent"),
 		WithZone("us-central1-f"),
@@ -58,5 +59,8 @@ func TestOptions(t *testing.T) {
 	}
 	if got, want := len(p.scopes), 2; got != want {
 		t.Errorf("Want %d scopes, got %d", want, got)
+  }
+	if got, want := p.serviceAccountEmail, "default"; got != want {
+		t.Errorf("Want service account name %q, got %q", want, got)
 	}
 }

--- a/drivers/google/option_test.go
+++ b/drivers/google/option_test.go
@@ -59,7 +59,7 @@ func TestOptions(t *testing.T) {
 	}
 	if got, want := len(p.scopes), 2; got != want {
 		t.Errorf("Want %d scopes, got %d", want, got)
-  }
+	}
 	if got, want := p.serviceAccountEmail, "default"; got != want {
 		t.Errorf("Want service account name %q, got %q", want, got)
 	}

--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -46,6 +46,7 @@ type provider struct {
 	privateIP  bool
 	project    string
 	scopes     []string
+	serviceAccountEmail string
 	size       string
 	tags       []string
 	zone       string
@@ -86,6 +87,9 @@ func New(opts ...Option) (autoscaler.Provider, error) {
 	}
 	if len(p.scopes) == 0 {
 		p.scopes = defaultScopes
+	}
+	if p.serviceAccountEmail == "" {
+	  p.serviceAccountEmail = "default"
 	}
 	if p.service == nil {
 		client, err := google.DefaultClient(oauth2.NoContext, compute.ComputeScope)

--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -47,10 +47,10 @@ type provider struct {
 	privateIP           bool
 	scopes              []string
 	serviceAccountEmail string
-	size       string
-	tags       []string
-	zone       string
-	userdata   *template.Template
+	size                string
+	tags                []string
+	zone                string
+	userdata            *template.Template
 
 	service *compute.Service
 }

--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -37,15 +37,15 @@ var (
 type provider struct {
 	init sync.Once
 
-	diskSize   int64
-	diskType   string
-	image      string
-	labels     map[string]string
-	network    string
-	subnetwork string
-	privateIP  bool
-	project    string
-	scopes     []string
+	diskSize            int64
+	diskType            string
+	image               string
+	labels              map[string]string
+	network             string
+	subnetwork          string
+	project             string
+	privateIP           bool
+	scopes              []string
 	serviceAccountEmail string
 	size       string
 	tags       []string
@@ -89,7 +89,7 @@ func New(opts ...Option) (autoscaler.Provider, error) {
 		p.scopes = defaultScopes
 	}
 	if p.serviceAccountEmail == "" {
-	  p.serviceAccountEmail = "default"
+		p.serviceAccountEmail = "default"
 	}
 	if p.service == nil {
 		client, err := google.DefaultClient(oauth2.NoContext, compute.ComputeScope)

--- a/provider.go
+++ b/provider.go
@@ -49,12 +49,13 @@ type Provider interface {
 // (e.g Digital Ocean Droplet).
 type Instance struct {
 	Provider ProviderType
-	ID       string
-	Name     string
-	Address  string
-	Region   string
-	Image    string
-	Size     string
+	ID                  string
+	Name                string
+	Address             string
+	Region              string
+	Image               string
+	Size                string
+	ServiceAccountEmail string
 }
 
 // InstanceCreateOpts define soptional instructions for


### PR DESCRIPTION
Adds option for passing an alternative GCP Service Account using the DRONE_GOOGLE_SERVICE_ACCOUNT_EMAIL env variable 

<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->