### PR TITLE
Negotiate API Version

### DIFF
--- a/engine/docker.go
+++ b/engine/docker.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/docker/docker/api"
 	docker "github.com/docker/docker/client"
 	"github.com/drone/autoscaler"
 )

--- a/engine/docker.go
+++ b/engine/docker.go
@@ -39,7 +39,10 @@ func newDockerClient(server *autoscaler.Server) (docker.APIClient, io.Closer, er
 			TLSClientConfig: tlsConfig,
 		},
 	}
-	host := fmt.Sprintf("https://%s:2376", server.Address)
-	dockerClient, err := docker.NewClient(host, api.DefaultVersion, client, nil)
+	dockerClient, err := docker.NewClientWithOpts(
+	   docker.WithAPIVersionNegotiation(),
+	   docker.WithHTTPClient(client),
+	   docker.WithHost(fmt.Sprintf("https://%s:2376", server.Address)),
+	)
 	return dockerClient, dockerClient, err
 }


### PR DESCRIPTION
The `docker.NewClient` function is deprecated for `docker.NewClientWithOpts`. Specify the already present options but also use API negotiation rather than using the explicit default version.

<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->