### PR TITLE
Add configuration to expose ports

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,7 @@ type (
 			EnvironFile string `envconfig:"DRONE_AGENT_ENV_FILE"`
 			Environ     []string
 			Volumes     []string
+			Ports       []string          `envconfig:"DRONE_AGENT_PUBLISHED_PORTS"`
 			Labels      map[string]string `envconfig:"DRONE_AGENT_LABELS"`
 		}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -66,6 +66,7 @@ func New(
 			secret:             config.Agent.Token,
 			envs:               config.Agent.Environ,
 			volumes:            config.Agent.Volumes,
+			ports:              config.Agent.Ports,
 			labels:             config.Agent.Labels,
 			proto:              config.Server.Proto,
 			host:               config.Server.Host,

--- a/engine/install.go
+++ b/engine/install.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	docker "github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
 )
 
 type installer struct {
@@ -33,6 +34,7 @@ type installer struct {
 	image            string
 	secret           string
 	volumes          []string
+	ports            []string
 	host             string
 	proto            string
 	envs             []string
@@ -216,6 +218,13 @@ poller:
 		mounts = nil
 	}
 
+	exposedPorts, portBindings, err := nat.ParsePortSpecs(i.ports)
+	if err != nil {
+		i.metrics.IncrServerInitError()
+		logger.WithError(err).Errorln("could not create port binding")
+		return i.errorUpdate(ctx, instance, err)
+	}
+
 	res, err := client.ContainerCreate(ctx,
 		&container.Config{
 			Image:        i.image,
@@ -223,6 +232,7 @@ poller:
 			AttachStderr: true,
 			Env:          envs,
 			Volumes:      toVol(volumes),
+			ExposedPorts: exposedPorts,
 			Labels: map[string]string{
 				"com.centurylinklabs.watchtower.enable":      "true",
 				"com.centurylinklabs.watchtower.stop-signal": "SIGHUP",
@@ -234,8 +244,9 @@ poller:
 			},
 		},
 		&container.HostConfig{
-			Binds:  volumes,
-			Mounts: mounts,
+			Binds:        volumes,
+			Mounts:       mounts,
+			PortBindings: portBindings,
 			RestartPolicy: container.RestartPolicy{
 				Name: "always",
 			},


### PR DESCRIPTION
Allows to expose additional ports on the runner. Uses the normal parsing code from docker's SDK

Useful with https://github.com/drone-runners/drone-runner-docker/pull/15