### PR TITLE
Allow setting user data key for Google Cloud

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -238,6 +238,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			google.WithScopes(c.Google.Scopes...),
 			google.WithUserData(c.Google.UserData),
 			google.WithUserDataFile(c.Google.UserDataFile),
+			google.WithUserDataKey(c.Google.UserDataKey),
 			google.WithZone(c.Google.Zone),
 		)
 	case c.DigitalOcean.Token != "":

--- a/config/config.go
+++ b/config/config.go
@@ -162,6 +162,7 @@ type (
 			Tags                []string          `envconfig:"DRONE_GOOGLE_TAGS"`
 			UserData            string            `envconfig:"DRONE_GOOGLE_USERDATA"`
 			UserDataFile        string            `envconfig:"DRONE_GOOGLE_USERDATA_FILE"`
+			UserDataKey         string            `envconfig:"DRONE_GOOGLE_USERDATA_KEY" default:"user-data"`
 			Zone                string            `envconfig:"DRONE_GOOGLE_ZONE"`
 		}
 

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -291,7 +291,8 @@ var jsonConfig = []byte(`{
       "prod"
     ],
     "UserData": "#cloud-init",
-    "UserDataFile": "/path/to/cloud/init.yml"
+    "UserDataFile": "/path/to/cloud/init.yml",
+	"UserDataKey": "user-data"
   },
   "HetznerCloud": {
     "Token": "12345678",

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -292,7 +292,7 @@ var jsonConfig = []byte(`{
     ],
     "UserData": "#cloud-init",
     "UserDataFile": "/path/to/cloud/init.yml",
-	"UserDataKey": "user-data"
+    "UserDataKey": "user-data"
   },
   "HetznerCloud": {
     "Token": "12345678",

--- a/drivers/google/create.go
+++ b/drivers/google/create.go
@@ -57,7 +57,7 @@ func (p *provider) Create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 		Metadata: &compute.Metadata{
 			Items: []*compute.MetadataItems{
 				{
-					Key:   "user-data",
+					Key:   p.userdataKey,
 					Value: googleapi.String(buf.String()),
 				},
 			},

--- a/drivers/google/option.go
+++ b/drivers/google/option.go
@@ -123,6 +123,16 @@ func WithUserDataFile(filepath string) Option {
 	}
 }
 
+// WithUserDataKey allows to set the user data key for Google Cloud Platform
+// This allows user to set either user-data or a startup script
+func WithUserDataKey(text string) Option {
+	return func(p *provider) {
+		if text != "" {
+			p.userdataKey = text
+		}
+	}
+}
+
 // WithZone returns an option to set the target zone.
 func WithZone(zone string) Option {
 	return func(p *provider) {

--- a/drivers/google/option_test.go
+++ b/drivers/google/option_test.go
@@ -23,6 +23,7 @@ func TestOptions(t *testing.T) {
 		WithTags("drone", "agent"),
 		WithZone("us-central1-f"),
 		WithScopes("scope1", "scope2"),
+		WithUserDataKey("test-key"),
 	)
 	if err != nil {
 		t.Error(err)
@@ -62,5 +63,8 @@ func TestOptions(t *testing.T) {
 	}
 	if got, want := p.serviceAccountEmail, "default"; got != want {
 		t.Errorf("Want service account name %q, got %q", want, got)
+	}
+	if got, want := p.userdataKey, "test-key"; got != want {
+		t.Errorf("Want userdata key %q, got %q", want, got)
 	}
 }

--- a/drivers/google/provider.go
+++ b/drivers/google/provider.go
@@ -51,6 +51,7 @@ type provider struct {
 	tags                []string
 	zone                string
 	userdata            *template.Template
+	userdataKey         string
 
 	service *compute.Service
 }
@@ -81,6 +82,9 @@ func New(opts ...Option) (autoscaler.Provider, error) {
 	}
 	if p.userdata == nil {
 		p.userdata = userdata.T
+	}
+	if p.userdataKey == "" {
+		p.userdataKey = "user-data"
 	}
 	if len(p.tags) == 0 {
 		p.tags = defaultTags

--- a/drivers/google/provider_test.go
+++ b/drivers/google/provider_test.go
@@ -46,6 +46,9 @@ func TestDefaults(t *testing.T) {
 	if p.userdata != userdata.T {
 		t.Errorf("Want default userdata template")
 	}
+	if p.userdataKey != "user-data" {
+		t.Errorf("Want default userdata key")
+	}
 	if got, want := p.zone, "us-central1-a"; got != want {
 		t.Errorf("Want region %q, got %q", want, got)
 	}


### PR DESCRIPTION
This allows a user to pass a startup script instead of user data
For example `windows-startup-script-ps1`