### PR TITLE
Correct planner's behaviour when there are no capacity left for buffer

### DIFF
--- a/engine/planner.go
+++ b/engine/planner.go
@@ -75,8 +75,8 @@ func (p *planner) Plan(ctx context.Context) error {
 
 	ctx = logger.WithContext(ctx, log)
 
-	free := max(capacity-running-p.buffer, 0)
-	diff := serverDiff(pending, free, p.cap)
+	free := max(capacity-running, 0)
+	diff := serverDiff(pending+p.buffer, free, p.cap)
 
 	// if the server differential to handle the build volume
 	// is positive, we can reduce server capacity.


### PR DESCRIPTION
Hi, I'm currently using this configuration: `DRONE_AGENT_CONCURRENCY=1`, `DRONE_CAPACITY_BUFFER=1`.
When there is only 1 server, 1 running build, I expect the autoscaler to scale the num of servers to `2` but the log say that no capacity changes required. 

I took a look the source code and found this:
https://github.com/drone/autoscaler/blob/290741f7c495d0cb0ca029e8ff0863586df99c43/engine/planner.go#L78
In the above case:
```
capacity = 1 (only 1 active server)
running = 1 (only 1 active build)
p.buffer = 1
-> free = max(1-1-1,0) = 0
-> diff = ceil(0-0)/1 = 0 
-> Since diff = 0, the autoscaler decides that no changes are required.
```

I think the problem is that `buffer` is included in `free` calculation, but `free` is forced to be at least 0, instead of -1 in this case.
So I move the buffer into `diff` calcuation, treating it as a `pending` build: `diff = serverDiff(pending+p.buffer, free, p.cap))`. This fixes the above issue while still keeps the logic that `free` must be at least 0.