### PR TITLE
Enable Reaper from main config

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -106,6 +106,7 @@ func New(
 			servers:  servers,
 			provider: provider,
 			interval: config.Reaper.Interval,
+			enabled:  config.Reaper.Enabled,
 		},
 	}
 }

--- a/engine/reaper.go
+++ b/engine/reaper.go
@@ -6,24 +6,12 @@ package engine
 
 import (
 	"context"
-	"os"
-	"strconv"
 	"sync"
 	"time"
 
 	"github.com/drone/autoscaler"
 	"github.com/drone/autoscaler/logger"
 )
-
-// this is a feature flag that can be used to enable
-// experimental reaping of errored instances.
-var enableReaper = false
-
-func init() {
-	enableReaper, _ = strconv.ParseBool(
-		os.Getenv("DRONE_ENABLE_REAPER"),
-	)
-}
 
 //
 // The reaper looks for and removes errored instances. The
@@ -39,11 +27,12 @@ type reaper struct {
 
 	servers  autoscaler.ServerStore
 	provider autoscaler.Provider
+	enabled  bool
 	interval time.Duration
 }
 
 func (r *reaper) Reap(ctx context.Context) error {
-	if !enableReaper {
+	if !r.enabled {
 		return nil
 	}
 


### PR DESCRIPTION
There are currently two flags for the reaper:
- DRONE_ENABLE_REAPER
- DRONE_REAPER_ENABLED

This removes the DRONE_ENABLE_REAPER flag which doesn't follow the regular pattern