### PR TITLE
Add option to specify Amazon EC2 instance metadata accessiblity

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -309,6 +309,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			amazon.WithVolumeIops(c.Amazon.VolumeIops),
 			amazon.WithIamProfileArn(c.Amazon.IamProfileArn),
 			amazon.WithMarketType(c.Amazon.MarketType),
+			amazon.WithInstanceMetadataTokens(c.Amazon.IMDSTokens),
 		), nil
 	case os.Getenv("OS_USERNAME") != "":
 		return openstack.New(

--- a/config/config.go
+++ b/config/config.go
@@ -132,6 +132,7 @@ type (
 			VolumeIops    int64  `envconfig:"DRONE_AMAZON_VOLUME_IOPS"`
 			IamProfileArn string `envconfig:"DRONE_AMAZON_IAM_PROFILE_ARN"`
 			MarketType    string `envconfig:"DRONE_AMAZON_MARKET_TYPE"`
+			IMDSTokens    string `envconfig:"DRONE_AMAZON_IMDS_TOKENS"`
 		}
 
 		DigitalOcean struct {

--- a/drivers/amazon/create.go
+++ b/drivers/amazon/create.go
@@ -106,6 +106,9 @@ func (p *provider) create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 				},
 			},
 		},
+		MetadataOptions: &ec2.InstanceMetadataOptionsRequest{
+			HttpTokens: aws.String(p.imdsTokens),
+		},
 	}
 
 	if p.volumeType == "io1" {

--- a/drivers/amazon/option.go
+++ b/drivers/amazon/option.go
@@ -151,3 +151,14 @@ func WithMarketType(t string) Option {
 		p.spotInstance = t == "spot"
 	}
 }
+
+// WithInstanceMetadataTokens returns an option to set the instance metadata service tokens requiment.
+func WithInstanceMetadataTokens(t string) Option {
+	return func(p *provider) {
+		if t == "required" || t == "optional" {
+			p.imdsTokens = t
+		} else {
+			panic("WithInstanceMetadataTokens option must either \"optional\" or \"required\"")
+		}
+	}
+}

--- a/drivers/amazon/provider.go
+++ b/drivers/amazon/provider.go
@@ -36,6 +36,7 @@ type provider struct {
 	tags          map[string]string
 	iamProfileArn string
 	spotInstance  bool
+	imdsTokens    string
 }
 
 func (p *provider) getClient() *ec2.EC2 {
@@ -77,6 +78,9 @@ func New(opts ...Option) autoscaler.Provider {
 	}
 	if p.userdata == nil {
 		p.userdata = userdata.T
+	}
+	if p.imdsTokens == "" {
+		p.imdsTokens = "optional"
 	}
 	return p
 }


### PR DESCRIPTION
Adds an option to set instance metadata service (IMDS) access option to require the usage of tokens (IMDSv2). The default value, "optional", will not change the current behavior.