### PR TITLE
Make drone agent prefix configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type (
 			Environ     []string
 			Volumes     []string
 			Labels      map[string]string `envconfig:"DRONE_AGENT_LABELS"`
+			Prefix      string            `envconfig:"DRONE_AGENT_PREFIX" default:"agent-"`
 		}
 
 		Runner Runner

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -84,6 +84,7 @@ func TestLoad(t *testing.T) {
 		"DRONE_AGENT_TOKEN":                "f5064039f5",
 		"DRONE_AGENT_IMAGE":                "drone/drone-runner-docker:latest",
 		"DRONE_AGENT_CONCURRENCY":          "2",
+		"DRONE_AGENT_PREFIX":               "agent-",
 		"DRONE_TLS_AUTOCERT":               "true",
 		"DRONE_TLS_CERT":                   "/path/to/cert.crt",
 		"DRONE_TLS_KEY":                    "/path/to/cert.key",
@@ -215,7 +216,8 @@ var jsonConfig = []byte(`{
     "Image": "drone/drone-runner-docker:latest",
     "Concurrency": 2,
     "KeepaliveTime": 360000000000,
-    "KeepaliveTimeout": 30000000000
+    "KeepaliveTimeout": 30000000000,
+	"Prefix": "agent-"
   },
   "HTTP": {
 	"Proto": "http",

--- a/server/servers.go
+++ b/server/servers.go
@@ -125,7 +125,7 @@ func HandleServerCreate(
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		server := &autoscaler.Server{
-			Name:     "agent-" + uniuri.NewLen(8),
+			Name:     config.Agent.Prefix + uniuri.NewLen(8),
 			State:    autoscaler.StatePending,
 			Capacity: config.Agent.Concurrency,
 		}


### PR DESCRIPTION
Adds:

* Configuration option to prefix agent server names