### PR TITLE
Add retries with backoff and randomness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/99designs/basicauth-go v0.0.0-20160802081356-2a93ba0f464d
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.7 // indirect
+	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/aws/aws-sdk-go v1.13.5
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a // indirect
 	github.com/bluele/slack v0.0.0-20171128075526-307046097ee9

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.4.7 h1:vOvDiY/F1avSWlCWiKJjdYKz2jVjTK3pWPHndeG4OAY=
 github.com/Microsoft/go-winio v0.4.7/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.13.5 h1:OomNUmMMCy/wClWVp5tl7FFMF+TmrjMksbmSuPziFj8=
 github.com/aws/aws-sdk-go v1.13.5/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a h1:BtpsbiV638WQZwhA98cEZw2BsbnQJrbd0BI7tsy0W1c=

--- a/store/servers.go
+++ b/store/servers.go
@@ -69,8 +69,9 @@ func (s *serverStore) Create(_ context.Context, server *autoscaler.Server) error
 		func() error {
 			if err := s.create(server); isConnReset(err) {
 				return err
+			} else {
+				return retry.Unrecoverable(err)
 			}
-			return retry.Unrecoverable(err)
 		},
 		retry.Attempts(5),
 		retry.MaxDelay(time.Second*5),
@@ -97,8 +98,9 @@ func (s *serverStore) Update(_ context.Context, server *autoscaler.Server) error
 		func() error {
 			if err := s.update(server); isConnReset(err) {
 				return err
+			} else {
+				return retry.Unrecoverable(err)
 			}
-			return retry.Unrecoverable(err)
 		},
 		retry.Attempts(5),
 		retry.MaxDelay(time.Second*5),

--- a/store/servers.go
+++ b/store/servers.go
@@ -64,21 +64,18 @@ func (s *serverStore) ListState(_ context.Context, state autoscaler.ServerState)
 	return dest, err
 }
 
-func (s *serverStore) Create(_ context.Context, server *autoscaler.Server) (err error) {
-	err = retry.Do(
+func (s *serverStore) Create(_ context.Context, server *autoscaler.Server) error {
+	return retry.Do(
 		func() error {
-			serverErr := s.create(server)
-
-			if !isConnReset(serverErr) {
-				return retry.Unrecoverable(serverErr)
+			if err := s.create(server); isConnReset(err) {
+				return err
 			}
-			return serverErr
+			return retry.Unrecoverable(err)
 		},
 		retry.Attempts(5),
 		retry.MaxDelay(time.Second*5),
 		retry.LastErrorOnly(true),
 	)
-	return err
 }
 
 func (s *serverStore) create(server *autoscaler.Server) error {
@@ -95,21 +92,18 @@ func (s *serverStore) create(server *autoscaler.Server) error {
 	return err
 }
 
-func (s *serverStore) Update(_ context.Context, server *autoscaler.Server) (err error) {
-	err = retry.Do(
+func (s *serverStore) Update(_ context.Context, server *autoscaler.Server) error {
+	return retry.Do(
 		func() error {
-			serverErr := s.update(server)
-
-			if !isConnReset(serverErr) {
-				return retry.Unrecoverable(serverErr)
+			if err := s.update(server); isConnReset(err) {
+				return err
 			}
-			return serverErr
+			return retry.Unrecoverable(err)
 		},
 		retry.Attempts(5),
 		retry.MaxDelay(time.Second*5),
 		retry.LastErrorOnly(true),
 	)
-	return err
 }
 
 func (s *serverStore) update(server *autoscaler.Server) error {


### PR DESCRIPTION
* Makes retries more explicit by using terms like `retry` and `uncrecoverable`.
* Adds a backoff between retries to prevent hammering the service with requests, and allowing time for the service to recover.
* Adds randomness to the backoff, so that if we have multiple instances of this code running, it reduces the likelihood that they'll all retry requests at the same time (and again hammering the service).
* Changes attempts to `5` and adds a max backoff delay of 5s (with the new backoff, this will end up nearly equivalent time-wise to the current code)