### PR TITLE
Allow setting the agent cpu architecture

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ type (
 			Image       string `default:"drone/drone-runner-docker:1"`
 			Concurrency int    `default:"2"`
 			OS          string `default:"linux"`
-			Arch        string `default:"amd64"`
+			Arch        string `envconfig:"DRONE_AGENT_ARCH" default:"amd64"`
 			Version     string
 			Kernel      string
 			EnvironFile string `envconfig:"DRONE_AGENT_ENV_FILE"`


### PR DESCRIPTION
Hi,

Let's say you'd like to run two autoscalers, one which provisions amd64 instances and another that launches arm64 instances.

In [discourse](https://discourse.drone.io/t/enhancement-allow-autoscaler-to-spin-up-different-machine-configurations/4906/2), Brad wrote something about it:  "If your Drone installation supports both amd64 and arm64 architectures, for example, you could run two separate autoscalers. You could run one autoscaler to provision arm64 servers on aws, and a second to provision amd64 servers on gcp. The autoscaler has matching logic [1] to facilitate this."

The question is, how does each of those autoscalers know in advance "I am the amd autoscaler" versus "I am the arm autoscaler"?   How do you set the parameter?  

In brief experimentation, there was no way to accomplish it, and the only way that I could imagine was setting an environment variable, since that's how everything else is usually configured.   The proposed change here adds "DRONE_AGENT_ARCH", for the autoscaler.   Then it was possible to launch arm instances.


