### PR TITLE
Bump DigitalOcean Docker Image to Ubuntu 20.04

### DIFF
--- a/drivers/digitalocean/provider.go
+++ b/drivers/digitalocean/provider.go
@@ -43,7 +43,7 @@ func New(opts ...Option) autoscaler.Provider {
 		p.size = "s-2vcpu-4gb"
 	}
 	if p.image == "" {
-		p.image = "docker-18-04"
+		p.image = "docker-20-04"
 	}
 	if p.userdata == nil {
 		p.userdata = userdataT


### PR DESCRIPTION
Docker CE 20.10.7

https://marketplace.digitalocean.com/apps/docker

We started getting some odd compilation errors in drone build, which appeared to be linked to the very old version of docker used by default in the agents (19.03.13). I recommend bumping this to a more stable version of.

`Ubuntu 18.04` - > `Ubuntu 20.04`
`Docker CE 19.03.13` -> Docker CE 20.10.7`

<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->