### PR TITLE
Set us-west-2 agent ami to 18.04 to avoid deprecation

### DIFF
--- a/drivers/amazon/util.go
+++ b/drivers/amazon/util.go
@@ -53,7 +53,7 @@ var images = map[string]string{
 	"ap-southeast-2": "ami-d38a4ab1",
 	"eu-west-2":      "ami-f4f21593",
 	"ap-northeast-2": "ami-a414b9ca",
-	"us-west-2":      "ami-4e79ed36",
+	"us-west-2":      "ami-0b152cfd354c4c7a4",
 	"us-east-2":      "ami-916f59f4",
 	"eu-west-3":      "ami-0e55e373",
 }


### PR DESCRIPTION
Change the default AWS AMI image for agents from 16.04 to 18.04 to avoid the deprecation notice.

<!-- IMPORTANT NOTICE

By submitting a pull request, you acknowledge that your contribution
will be under the terms of the BSD-3-Clause license.

    https://opensource.org/licenses/BSD-3-Clause

-->