### PR TITLE
search for not_found code explicitly before returning ErrInstanceNotFound

### DIFF
--- a/drivers/hetznercloud/destroy.go
+++ b/drivers/hetznercloud/destroy.go
@@ -6,7 +6,9 @@ package hetznercloud
 
 import (
 	"context"
+	"io"
 	"strconv"
+	"strings"
 
 	"github.com/drone/autoscaler"
 	"github.com/drone/autoscaler/logger"
@@ -28,10 +30,13 @@ func (p *provider) Destroy(ctx context.Context, instance *autoscaler.Instance) e
 
 	logger.Debugln("deleting instance")
 
-	_, err = p.client.Server.Delete(ctx, &hcloud.Server{ID: id})
+	msg, err := p.client.Server.Delete(ctx, &hcloud.Server{ID: id})
 
 	if err != nil {
-		if err.Error() == "hcloud: server responded with status code 404" {
+		// json response contains a code=not_found field
+		msgBytes, err2 := io.ReadAll(msg.Response.Body)
+		msgStr := string(msgBytes)
+		if err2 == nil && strings.Contains(msgStr, "not_found") {
 			logger.WithError(err).
 				Debugln("instance does not exist")
 			return autoscaler.ErrInstanceNotFound


### PR DESCRIPTION
When a hetzner cloud instance is deleted externally (not by the autoscaler, for example via GUI/API) the autoscaler fails to correctly terminate the instance. This is due to the fact that it does not return ErrInstanceNotFound but a generic one.

Example log:
```
{"image":"ubuntu-20.04","level":"debug","msg":"deleting instance","name":"agent-QpBgrGhL","region":"unknown","size":"cpx11","time":"2022-09-22T13:57:36Z"}
{"error":"server with ID '24078837' not found (not_found)","image":"ubuntu-20.04","level":"error","msg":"deleting instance failed","name":"agent-QpBgrGhL","region":"unknown","size":"cpx11","time":"2022-09-22T13:57:37Z"}
{"error":"server with ID '24078837' not found (not_found)","level":"error","msg":"cannot destroy server","server":"agent-QpBgrGhL","state":"error","time":"2022-09-22T13:57:37Z"}
```
As you can the the hetzner response with code=not_found but the implementation returns a generic error as indicated by the log message "cannot destroy server" (reaper.go#107)

Instead of relying on the generic error response here which seems to have changed it will now check for the string not_found in the hetzner api response and if found return ErrInstanceNotFound allowing the instance to be deleted from the autoscaler.