### PR TITLE
Feature: support minimum idle time before terminating server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,9 +32,10 @@ type (
 		}
 
 		Pool struct {
-			Min    int           `default:"2"`
-			Max    int           `default:"4"`
-			MinAge time.Duration `default:"55m" split_words:"true"`
+			Min     int           `default:"2"`
+			Max     int           `default:"4"`
+			MinAge  time.Duration `default:"55m" split_words:"true"`
+			MinIdle time.Duration `default:"0" split_words:"true"`
 		}
 
 		Check struct {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -35,6 +35,9 @@ func TestDefaults(t *testing.T) {
 	if got, want := conf.Pool.MinAge, time.Minute*55; got != want {
 		t.Errorf("Want default DRONE_POOL_MIN_AGE of %d, got %d", want, got)
 	}
+	if got, want := conf.Pool.MinIdle, time.Minute*0; got != want {
+		t.Errorf("Want default DRONE_POOL_MIN_IDLE of %d, got %d", want, got)
+	}
 
 	if got, want := conf.Check.Interval, time.Minute; got != want {
 		t.Errorf("Want default DRONE_INSTALL_CHECK_INTERVAL of %s, got %s", want, got)
@@ -74,6 +77,7 @@ func TestLoad(t *testing.T) {
 		"DRONE_LOGS_PRETTY":                "true",
 		"DRONE_CAPACITY_BUFFER":            "3",
 		"DRONE_POOL_MIN_AGE":               "1h",
+		"DRONE_POOL_MIN_IDLE":              "15m",
 		"DRONE_POOL_MIN":                   "1",
 		"DRONE_POOL_MAX":                   "5",
 		"DRONE_SERVER_HOST":                "drone.company.com",
@@ -204,7 +208,8 @@ var jsonConfig = []byte(`{
   "Pool": {
     "Min": 1,
     "Max": 5,
-    "MinAge": 3600000000000
+    "MinAge": 3600000000000,
+    "MinIdle": 900000000000
   },
   "Server": {
     "Host": "drone.company.com",

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -100,6 +100,7 @@ func New(
 			kernel:     config.Agent.Kernel,
 			buffer:     config.CapacityBuffer,
 			ttu:        config.Pool.MinAge,
+			tti:        config.Pool.MinIdle,
 			min:        config.Pool.Min,
 			max:        config.Pool.Max,
 			cap:        config.Agent.Concurrency,

--- a/engine/planner.go
+++ b/engine/planner.go
@@ -186,7 +186,7 @@ func (p *planner) mark(ctx context.Context, n int) error {
 			continue
 		}
 
-		// skipi servers that have not reached a min idle time
+		// skip servers that have not reached a min idle time
 		if time.Now().Before(time.Unix(server.Updated, 0).Add(p.tti)) {
 			logger.
 				WithField("server", server.Name).

--- a/engine/planner.go
+++ b/engine/planner.go
@@ -186,6 +186,16 @@ func (p *planner) mark(ctx context.Context, n int) error {
 			continue
 		}
 
+		// skipi servers that have not reached a min idle time
+		if time.Now().Before(time.Unix(server.Updated, 0).Add(p.tti)) {
+			logger.
+				WithField("server", server.Name).
+				WithField("idle", timeDiff(time.Now(), time.Unix(server.Updated, 0))).
+				WithField("min-idle", p.tti).
+				Debugln("server min-idle not reached")
+			continue
+		}
+
 		idle = append(idle, server)
 		logger.WithField("server", server.Name).
 			Debugln("server is idle")

--- a/engine/planner.go
+++ b/engine/planner.go
@@ -30,6 +30,7 @@ type planner struct {
 	cap        int           // capacity per-server
 	buffer     int           // buffer capacity to have warm and ready
 	ttu        time.Duration // minimum server age
+	tti        time.Duration // minimum server idle time
 	labels     map[string]string
 
 	client  drone.Client


### PR DESCRIPTION
This attempts to add support for `DRONE_POOL_MIN_IDLE`, which will define the minimum idle time before a server is terminated.  It defaults to `0`, but if you set it to `30m` then it will only terminate a server after it has sat idle for at least 30 minutes (no jobs have run).  It utilizes the `Updated` server property, which I believe gets updated as the server changes state from `running` to `pending` status.  As it completes the builds, this should represent when the last build finished.  As such, if jobs continue to fire regularly, then it stays online, but if jobs stop, it would then terminate after this duration.

I'm currently trying to get a test installation online to test these changes, but figured I'd see if folks had feedback regardless.