### PR TITLE
AWS: Allow using a list of subnets

### DIFF
--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -311,7 +311,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			amazon.WithSecurityGroup(c.Amazon.SecurityGroup...),
 			amazon.WithSize(c.Amazon.Instance),
 			amazon.WithSizeAlt(c.Amazon.InstanceAlt),
-			amazon.WithSubnet(c.Amazon.SubnetID),
+			amazon.WithSubnets(c.Amazon.SubnetID),
 			amazon.WithTags(c.Amazon.Tags),
 			amazon.WithUserData(c.Amazon.UserData),
 			amazon.WithUserDataFile(c.Amazon.UserDataFile),

--- a/cmd/drone-autoscaler/main.go
+++ b/cmd/drone-autoscaler/main.go
@@ -311,7 +311,7 @@ func setupProvider(c config.Config) (autoscaler.Provider, error) {
 			amazon.WithSecurityGroup(c.Amazon.SecurityGroup...),
 			amazon.WithSize(c.Amazon.Instance),
 			amazon.WithSizeAlt(c.Amazon.InstanceAlt),
-			amazon.WithSubnets(c.Amazon.SubnetID),
+			amazon.WithSubnets(append([]string{c.Amazon.SubnetID}, c.Amazon.SubnetIDsAlt...)),
 			amazon.WithTags(c.Amazon.Tags),
 			amazon.WithUserData(c.Amazon.UserData),
 			amazon.WithUserDataFile(c.Amazon.UserDataFile),

--- a/config/config.go
+++ b/config/config.go
@@ -131,7 +131,7 @@ type (
 			Region           string
 			Retries          int
 			SSHKey           string
-			SubnetID         string   `split_words:"true"`
+			SubnetID         []string `split_words:"true"`
 			SecurityGroup    []string `split_words:"true"`
 			Tags             map[string]string
 			UserData         string `envconfig:"DRONE_AMAZON_USERDATA"`

--- a/config/config.go
+++ b/config/config.go
@@ -131,7 +131,8 @@ type (
 			Region           string
 			Retries          int
 			SSHKey           string
-			SubnetID         []string `split_words:"true"`
+			SubnetID         string   `split_words:"true"`
+			SubnetIDsAlt     []string `envconfig:"DRONE_AMAZON_SUBNET_IDS_ALT"` // In the same manner as InstanceAlt, allows fallback to other subnets if provisioning in the main one fails
 			SecurityGroup    []string `split_words:"true"`
 			Tags             map[string]string
 			UserData         string `envconfig:"DRONE_AMAZON_USERDATA"`

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -263,7 +263,9 @@ var jsonConfig = []byte(`{
     "Retries": 1,
     "Region": "us-east-2",
     "SSHKey": "id_rsa",
-    "SubnetID": "subnet-0b32177f",
+    "SubnetID": [
+		"subnet-0b32177f"
+	],
     "SecurityGroup": [
       "sg-770eabe1"
     ],

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -125,6 +125,7 @@ func TestLoad(t *testing.T) {
 		"DRONE_AMAZON_REGION":              "us-east-2",
 		"DRONE_AMAZON_SSHKEY":              "id_rsa",
 		"DRONE_AMAZON_SUBNET_ID":           "subnet-0b32177f",
+		"DRONE_AMAZON_SUBNET_IDS_ALT":      "subnet-abcd,subnet-efgh",
 		"DRONE_AMAZON_SECURITY_GROUP":      "sg-770eabe1",
 		"DRONE_AMAZON_TAGS":                "os:linux,arch:amd64",
 		"DRONE_AMAZON_USERDATA":            "#cloud-init",
@@ -263,8 +264,10 @@ var jsonConfig = []byte(`{
     "Retries": 1,
     "Region": "us-east-2",
     "SSHKey": "id_rsa",
-    "SubnetID": [
-		"subnet-0b32177f"
+    "SubnetID": "subnet-0b32177f",
+    "SubnetIDsAlt": [
+		"subnet-abcd",
+		"subnet-efgh"
 	],
     "SecurityGroup": [
       "sg-770eabe1"

--- a/drivers/amazon/option.go
+++ b/drivers/amazon/option.go
@@ -78,10 +78,10 @@ func WithSSHKey(key string) Option {
 	}
 }
 
-// WithSubnet returns an option to set the subnet id.
-func WithSubnet(id string) Option {
+// WithSubnets returns an option to set the subnet ids.
+func WithSubnets(ids []string) Option {
 	return func(p *provider) {
-		p.subnet = id
+		p.subnets = ids
 	}
 }
 

--- a/drivers/amazon/option_test.go
+++ b/drivers/amazon/option_test.go
@@ -16,7 +16,7 @@ func TestOptions(t *testing.T) {
 		WithSecurityGroup("sg-770eabe1"),
 		WithSize("t3.2xlarge"),
 		WithSSHKey("id_rsa"),
-		WithSubnet("subnet-0b32177f"),
+		WithSubnets([]string{"subnet-0b32177f"}),
 		WithTags(map[string]string{"foo": "bar", "baz": "qux"}),
 		WithVolumeSize(64),
 		WithVolumeType("io1"),
@@ -40,7 +40,7 @@ func TestOptions(t *testing.T) {
 	if got, want := p.groups[0], "sg-770eabe1"; got != want {
 		t.Errorf("Want security groups %q, got %q", want, got)
 	}
-	if got, want := p.subnet, "subnet-0b32177f"; got != want {
+	if got, want := p.subnets, []string{"subnet-0b32177f"}; len(got) != 1 || got[0] != want[0] {
 		t.Errorf("Want subnet %q, got %q", want, got)
 	}
 	if got, want := p.retries, 10; got != want {

--- a/drivers/amazon/provider.go
+++ b/drivers/amazon/provider.go
@@ -32,7 +32,7 @@ type provider struct {
 	userdata         *template.Template
 	size             string
 	sizeAlt          string
-	subnet           string
+	subnets          []string
 	groups           []string
 	tags             map[string]string
 	iamProfileArn    string

--- a/drivers/amazon/setup.go
+++ b/drivers/amazon/setup.go
@@ -21,7 +21,7 @@ func (p *provider) setup(ctx context.Context) error {
 			return p.setupKeypair(ctx)
 		})
 	}
-	if p.subnet == "" {
+	if len(p.subnets) == 0 {
 		// TODO: find or create subnet
 	}
 	if len(p.groups) == 0 {


### PR DESCRIPTION
When using more specialized instance types, it may happen that they aren't available in the given AZ
By giving multiple subnets, it allows the autoscaler to retry in a different AZ when that happens

I saw a TODO about using a small struct to track attempts. By adding that, I could extend the current sizeAlt behavior
The autoscaler will now try the regular size in all subnets, then the alternate size in all subnets

This is what the output looks like when combined with a size alt (2 invalid subnets + 1 invalid machine type):

```
{"attempt":1,"image":"ami-00149760ce42c967b","level":"debug","msg":"instance create","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"blabla","subnet":"a","time":"2023-01-30T16:50:54Z"}
{"attempt":1,"error":"InvalidParameterValue: Invalid value 'blabla' for InstanceType.\n\tstatus code: 400, request id: 24a9131c-b46a-4afe-87e0-adea1b509232","image":"ami-00149760ce42c967b","level":"error","msg":"instance create failed","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"blabla","subnet":"a","time":"2023-01-30T16:50:54Z"}
{"attempt":2,"image":"ami-00149760ce42c967b","level":"debug","msg":"instance create","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"blabla","subnet":"b","time":"2023-01-30T16:50:54Z"}
{"attempt":2,"error":"InvalidParameterValue: Invalid value 'blabla' for InstanceType.\n\tstatus code: 400, request id: 34d7a00a-dd9f-4689-93fe-3fc5238404df","image":"ami-00149760ce42c967b","level":"error","msg":"instance create failed","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"blabla","subnet":"b","time":"2023-01-30T16:50:55Z"}
{"attempt":3,"image":"ami-00149760ce42c967b","level":"debug","msg":"instance create","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"blabla","subnet":"<redacted>","time":"2023-01-30T16:50:55Z"}
{"attempt":3,"error":"InvalidParameterValue: Invalid value 'blabla' for InstanceType.\n\tstatus code: 400, request id: 2a3d3e92-6fc3-4343-adff-b62f9d31b390","image":"ami-00149760ce42c967b","level":"error","msg":"instance create failed","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"blabla","subnet":"<redacted>","time":"2023-01-30T16:50:55Z"}
{"attempt":4,"image":"ami-00149760ce42c967b","level":"debug","msg":"instance create","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"m6i.large","subnet":"a","time":"2023-01-30T16:50:55Z"}
{"attempt":4,"error":"InvalidSubnetID.NotFound: The subnet ID 'a' does not exist\n\tstatus code: 400, request id: 1e4e7e07-56c6-489e-b01a-a0ba1fcca1c5","image":"ami-00149760ce42c967b","level":"error","msg":"instance create failed","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"m6i.large","subnet":"a","time":"2023-01-30T16:50:56Z"}
{"attempt":5,"image":"ami-00149760ce42c967b","level":"debug","msg":"instance create","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"m6i.large","subnet":"b","time":"2023-01-30T16:50:56Z"}
{"attempt":5,"error":"InvalidSubnetID.NotFound: The subnet ID 'b' does not exist\n\tstatus code: 400, request id: 7974f101-a5cd-4ed6-831d-7731dda2f172","image":"ami-00149760ce42c967b","level":"error","msg":"instance create failed","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"m6i.large","subnet":"b","time":"2023-01-30T16:50:56Z"}
{"attempt":6,"image":"ami-00149760ce42c967b","level":"debug","msg":"instance create","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"m6i.large","subnet":"<redacted>","time":"2023-01-30T16:50:56Z"}
{"attempt":6,"image":"ami-00149760ce42c967b","level":"info","msg":"instance create success","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"m6i.large","subnet":"<redacted>","time":"2023-01-30T16:50:57Z"}
{"attempt":6,"image":"ami-00149760ce42c967b","level":"debug","msg":"check instance network","name":"drone-linux-aws-amd64-ZQumcEFd","region":"us-east-2","size":"m6i.large","subnet":"<redacted>","time":"2023-01-30T16:50:57Z"}
```