### PR TITLE
Update amazon session.New to support web identity token from service account in K8s

### DIFF
--- a/drivers/amazon/provider.go
+++ b/drivers/amazon/provider.go
@@ -43,7 +43,8 @@ func (p *provider) getClient() *ec2.EC2 {
 	config := aws.NewConfig()
 	config = config.WithRegion(p.region)
 	config = config.WithMaxRetries(p.retries)
-	return ec2.New(session.New(config))
+	session, _ := session.NewSession(config)
+	return ec2.New(session)
 }
 
 // New returns a new Digital Ocean provider.


### PR DESCRIPTION
Hi Everyone !

While trying to get the drone autoscaler running on Amazon EKS Kubernetes cluster I encountered an issue with the way the AWS SDK handles the session when using an IAM role.

The drone autoscaler deployment is assigned a ServiceAccount to grant the service access to an IAM role (IRSA / OIDC IAM role dedicated to the pod) as stated in this documentation https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html

While digging into AWS SDK issues I found this relevant issue that makes a mention of using `session.NewSession` instead  of `session.New` which does not handle well web identity token files https://github.com/aws/aws-sdk-go/issues/4436

I made a local build of the project and took it for a spin and it works like charm now. The Drone autoscaler service is able to assume the ServiceAccount IAM role instead of the IAM role assigned to the EC2 machine.

* Here are the relevant Drone autoscaler env vars I am using:

``` 
AWS_IAM: true
DRONE_AMAZON_IAM_PROFILE_ARN: arn:aws:iam::123456789101:instance-profile/drone-autoscaler
```

* The Service Account object looks like this

```
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789101:role/drone-autoscaler
    meta.helm.sh/release-name: drone-autoscaler--production
    meta.helm.sh/release-namespace: cicd
  creationTimestamp: "2023-04-18T09:55:18Z"
  labels:
    release: drone-autoscaler--production
  name: drone-autoscaler--production-monochart-default
  namespace: cicd
secrets:
- name: drone-autoscaler--production-monochart-default-token-fzgrm
```

* I used the IAM policy for the drone autoscaler suggested by @mtb-xt on the community forum https://community.harness.io/t/drone-autoscaler/10719/12

* The IAM trusted policy is as follow:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::123456789101:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/<OIDC_ID>"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringLike": {
                    "oidc.eks.us-east-1.amazonaws.com/id/<OIDC_ID>": "system:serviceaccount:cicd:drone-autoscaler--production-monochart-default"
                }
            }
        }
    ]
}
```