### PR TITLE
fix: [CI-12899]: Added tag support for EBS volume

### DIFF
--- a/drivers/amazon/create.go
+++ b/drivers/amazon/create.go
@@ -122,6 +122,10 @@ func (p *provider) create(ctx context.Context, opts autoscaler.InstanceCreateOpt
 				ResourceType: aws.String("instance"),
 				Tags:         convertTags(tags),
 			},
+			{
+				ResourceType: aws.String("volume"),
+				Tags:         convertTags(tags),
+			},
 		},
 		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 			{


### PR DESCRIPTION
Before Tag change
<img width="1728" alt="Screenshot 2024-06-17 at 11 04 39 PM" src="https://github.com/drone/autoscaler/assets/139750384/69188787-7894-41b1-9692-6a5488f18d70">
<img width="1727" alt="Screenshot 2024-06-17 at 11 38 21 PM" src="https://github.com/drone/autoscaler/assets/139750384/e32f18dc-87c7-404f-99f1-14e00c5b8495">

After Tag change
<img width="1728" alt="Screenshot 2024-06-17 at 11 54 28 PM" src="https://github.com/drone/autoscaler/assets/139750384/f247c71c-2c54-4f9e-afe2-bbb51081cac8">
<img width="1725" alt="Screenshot 2024-06-17 at 11 55 58 PM" src="https://github.com/drone/autoscaler/assets/139750384/6a6ea10c-5a9e-4f4b-9590-5bd56922ce77">
