### PR TITLE
Fix Hetzner 404 error detection during server destruction

### DIFF
--- a/drivers/hetznercloud/destroy.go
+++ b/drivers/hetznercloud/destroy.go
@@ -31,7 +31,7 @@ func (p *provider) Destroy(ctx context.Context, instance *autoscaler.Instance) e
 	_, err = p.client.Server.Delete(ctx, &hcloud.Server{ID: id})
 
 	if err != nil {
-		if err.Error() == "hcloud: server responded with status code 404" {
+		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
 			logger.WithError(err).
 				Debugln("instance does not exist")
 			return autoscaler.ErrInstanceNotFound

--- a/drivers/hetznercloud/destroy_test.go
+++ b/drivers/hetznercloud/destroy_test.go
@@ -62,6 +62,7 @@ func TestDestroyNotFound(t *testing.T) {
 	gock.New("https://api.hetzner.cloud").
 		Delete("/v1/servers/3164494").
 		Reply(404).
+		SetHeader("Content-Type", "application/json").
 		BodyString(destroyNotFoundResponse)
 
 	mockContext := context.TODO()


### PR DESCRIPTION
The Reaper component is unable to properly clean up errored Hetzner servers because 404 errors when destroying non-existent servers are not correctly detected. The current implementation relies on checking human-facing error messages, which are fragile and subject to change.

When the Reaper attempts to destroy an errored server that no longer exists on Hetzner, the 404 response is not recognized as `autoscaler.ErrInstanceNotFound`. This prevents the Reaper from correctly marking the server as stopped, causing it to remain in the error state indefinitely.

Use the Hetzner Cloud SDK's machine-facing error code detection (`hcloud.IsError(err, hcloud.ErrorCodeNotFound)`). The machine facing error code is documented in the [Hetzner API reference](https://docs.hetzner.cloud/reference/cloud#tag/servers/delete_server). This provides a stable, version-independent way to detect not-found errors and properly classify them as `autoscaler.ErrInstanceNotFound`.

This should:
- Enable the Reaper to correctly handle scenarios where servers have been manually terminated outside the autoscaler
- Prevents errored servers from becoming stuck in the error state
- Improves reliability of cleanup operations for Hetzner cloud instances

Alternative to: https://github.com/drone/autoscaler/pull/121

Edit: Improved PR title and description.